### PR TITLE
Update Discord Version to 0.0.15

### DIFF
--- a/packages/discord/discord.pacscript
+++ b/packages/discord/discord.pacscript
@@ -1,12 +1,12 @@
 name="discord"
-version="0.0.14"
+version="0.0.15"
 maintainer="aranym <aranym1@pm.me>"
-url="https://dl.discordapp.net/apps/linux/0.0.14/discord-0.0.14.tar.gz"
+url="https://dl.discordapp.net/apps/linux/0.0.15/discord-0.0.15.tar.gz"
 build_depends=""
 depends="libc6 libasound2 libatomic1 libgconf-2-4 libnotify4 libnspr4 libnss3 libstdc++6 libxss1 libxtst6 libappindicator1 libc++1"
 gives="discord"
 description="Chat for Communities and Friends"
-hash="c2651aef4b2c078a3d0975b82fd391571decaa636e52343bb4f116da1c4804e7"
+hash="adede954e9c696d96e254759b539527a24ab1d42f0d548c5c4309d1a3fc3c25e"
 
 prepare() {
         sudo mkdir -p /usr/src/pacstall/discord/usr/share/discord/


### PR DESCRIPTION
Discord sometimes can't auto update on linux due to having to change files in directories outside the home directory which it can't because of permissions. Recently version 0.0.15 was released.