### PR TITLE
Update Soundux pacscript

### DIFF
--- a/packages/soundux/soundux.pacscript
+++ b/packages/soundux/soundux.pacscript
@@ -23,11 +23,11 @@ build() {
 install() {
   sudo make install DESTDIR="$pkgdir"
   # install binary symlink
-  mkdir -p "$pkgdir/usr/bin/"
-  ln -sf /opt/soundux/soundux "$pkgdir/usr/bin/soundux"
+  sudo mkdir -p "$pkgdir/usr/bin/"
+  sudo ln -sf /opt/soundux/soundux "$pkgdir/usr/bin/soundux"
   
   # install doc
-  install -Dm 644 -t "$pkgdir/usr/share/doc/$name" "../README.md"
+  sudo install -Dm 644 -t "$pkgdir/usr/share/doc/$name" "../README.md"
   # install license
-  install -Dm 644 -t "$pkgdir/usr/share/licenses/$name" "../LICENSE"
+  sudo install -Dm 644 -t "$pkgdir/usr/share/licenses/$name" "../LICENSE"
 }

--- a/packages/soundux/soundux.pacscript
+++ b/packages/soundux/soundux.pacscript
@@ -1,4 +1,5 @@
 name="soundux"
+pkgdir="/usr/src/pacstall/$name"
 version="0.2.7"
 url="https://github.com/Soundux/Soundux/releases/download/$version/soundux-$version.tar.gz"
 build_depends="cmake libx11-dev libxi-dev libwebkit2gtk-4.0-dev libappindicator3-dev libssl-dev libpulse-dev"
@@ -20,5 +21,13 @@ build() {
 }
 
 install() {
-  sudo make install DESTDIR=/usr/src/pacstall/soundux
+  sudo make install DESTDIR="$pkgdir"
+  # install binary symlink
+  mkdir -p "$pkgdir/usr/bin/"
+  ln -sf /opt/soundux/soundux "$pkgdir/usr/bin/soundux"
+  
+  # install doc
+  install -Dm 644 -t "$pkgdir/usr/share/doc/$name" "../README.md"
+  # install license
+  install -Dm 644 -t "$pkgdir/usr/share/licenses/$name" "../LICENSE"
 }

--- a/packages/soundux/soundux.pacscript
+++ b/packages/soundux/soundux.pacscript
@@ -9,7 +9,7 @@ maintainer="D3SOX <d3sox@protonmail.com>"
 removescript="yes"
 
 _ubuntuver=$(grep "VERSION_ID=" /etc/os-release | grep -o "[0-9]*" | tr -d '[:space:]')
-if [ $_ubuntuver -ge 2010 ]; then
+if [ "$_ubuntuver" -ge 2010 ]; then
   depends="libgtk-3-0 libwnck-3-0 libappindicator3-1 libwebkit2gtk-4.0-37 libx11-6 pulseaudio libpipewire-0.3-dev"
 else
   depends="libgtk-3-0 libwnck-3-0 libappindicator3-1 libwebkit2gtk-4.0-37 libx11-6 pulseaudio"

--- a/packages/soundux/soundux.pacscript
+++ b/packages/soundux/soundux.pacscript
@@ -6,6 +6,7 @@ build_depends="cmake libx11-dev libxi-dev libwebkit2gtk-4.0-dev libappindicator3
 description="A cross-platform soundboard"
 hash="017003fc96f49df30575975f3904c0d8a500e325a9d2bca8c3dc69fed0cab0a7"
 maintainer="D3SOX <d3sox@protonmail.com>"
+removescript="yes"
 
 _ubuntuver=$(grep "VERSION_ID=" /etc/os-release | grep -o "[0-9]*" | tr -d '[:space:]')
 if [ $_ubuntuver -ge 2010 ]; then
@@ -33,4 +34,9 @@ install() {
   sudo install -Dm 644 -t "$pkgdir/usr/share/doc/$name" "../README.md"
   # install license
   sudo install -Dm 644 -t "$pkgdir/usr/share/licenses/$name" "../LICENSE"
+}
+
+removescript() {
+    sudo rm -rf "/usr/share/doc/$name"
+    sudo rm -rf "/usr/share/licenses/$name"
 }

--- a/packages/soundux/soundux.pacscript
+++ b/packages/soundux/soundux.pacscript
@@ -3,11 +3,17 @@ pkgdir="/usr/src/pacstall/$name"
 version="0.2.7"
 url="https://github.com/Soundux/Soundux/releases/download/$version/soundux-$version.tar.gz"
 build_depends="cmake libx11-dev libxi-dev libwebkit2gtk-4.0-dev libappindicator3-dev libssl-dev libpulse-dev"
-depends="libgtk-3-0 libwnck-3-0 libappindicator3-1 libwebkit2gtk-4.0-37 libx11-6 pulseaudio"
 description="A cross-platform soundboard"
 hash="017003fc96f49df30575975f3904c0d8a500e325a9d2bca8c3dc69fed0cab0a7"
 maintainer="D3SOX <d3sox@protonmail.com>"
-pacdeps=("pipewire")
+
+_ubuntuver=$(grep "VERSION_ID=" /etc/os-release | grep -o "[0-9]*" | tr -d '[:space:]')
+if [ $_ubuntuver -ge 2010 ]; then
+  depends="libgtk-3-0 libwnck-3-0 libappindicator3-1 libwebkit2gtk-4.0-37 libx11-6 pulseaudio libpipewire-0.3-dev"
+else
+  depends="libgtk-3-0 libwnck-3-0 libappindicator3-1 libwebkit2gtk-4.0-37 libx11-6 pulseaudio"
+  pacdeps=("pipewire")
+fi
 
 prepare() {
   true
@@ -22,9 +28,6 @@ build() {
 
 install() {
   sudo make install DESTDIR="$pkgdir"
-  # install binary symlink
-  sudo mkdir -p "$pkgdir/usr/bin/"
-  sudo ln -sf /opt/soundux/soundux "$pkgdir/usr/bin/soundux"
   
   # install doc
   sudo install -Dm 644 -t "$pkgdir/usr/share/doc/$name" "../README.md"


### PR DESCRIPTION
This now installs the doc, license and a binary symlink that it can be started via `soundux` in the terminal