### PR TITLE
Add lsd-deb 0.20.1

### DIFF
--- a/packages/lsd-deb/README.md
+++ b/packages/lsd-deb/README.md
@@ -1,0 +1,12 @@
+# lsd deb
+
+* [lsd](https://github.com/Peltoche/lsd)
+
+## Description
+
+This project is heavily inspired by the super [colorls](https://github.com/athityakumar/colorls)
+project but with some little differences.  For example it is written in rust and not in ruby which makes it much faster.
+
+## Screenshot
+
+![image](https://raw.githubusercontent.com/Peltoche/lsd/assets/screen_lsd.png)

--- a/packages/lsd-deb/lsd-deb.pacscript
+++ b/packages/lsd-deb/lsd-deb.pacscript
@@ -1,0 +1,7 @@
+name="lsd-deb"
+version="0.20.1"
+gives="lsd"
+url="https://github.com/Peltoche/lsd/releases/download/0.20.1/lsd_${version}_amd64.deb"
+description="This project is heavily inspired by the super colorls project but with some little differences. For example it is written in rust and not in ruby which makes it much faster."
+hash="bbe179579e3a242247577d4731f780462aa1cb21397a7dfc266d0050ac42691b"
+maintainer="KwonNam Son <kwon37xi@gmail.com>"


### PR DESCRIPTION
I added lsd-deb pacscript.
https://github.com/Peltoche/lsd : `exa/colorls` like `ls` replacement.