### PR TITLE
fix(bpytop-git): Add `--upgrade` flag

### DIFF
--- a/packages/bpytop-git/bpytop-git.pacscript
+++ b/packages/bpytop-git/bpytop-git.pacscript
@@ -13,7 +13,7 @@ version="$(pkgver)"
 removescript="yes"
 
 prepare() {
-    sudo pip3 install psutil
+    sudo pip3 install --upgrade psutil
 }
 
 build() {


### PR DESCRIPTION
Fixes `bpytop-git`'s `psutil` installation. Previously if an older `psutil` version was installed then it was not updated. Which resulted in breakage. This fixes that.

Maintainer: @WRM-42 