### PR TITLE
Remove Axel from CI

### DIFF
--- a/.github/workflows/test-package-install.yml
+++ b/.github/workflows/test-package-install.yml
@@ -15,7 +15,7 @@ jobs:
         run: |
           export PACSTALL_SKIP_NETWORK_CHECK=1
           sudo bash -c "$(wget -q https://git.io/JsADh -O -)"
-          apt remove -y axel
+          sudo apt remove -y axel
       - name: Installing packages with pacstall
         run: | 
           sudo dpkg --add-architecture i386

--- a/.github/workflows/test-package-install.yml
+++ b/.github/workflows/test-package-install.yml
@@ -16,7 +16,8 @@ jobs:
           export PACSTALL_SKIP_NETWORK_CHECK=1
           sudo bash -c "$(wget -q https://git.io/JsADh -O -)"
           sudo apt remove -y axel
-          chmod u+w /tmp/
+          mkdir -p /tmp/pacstall || sudo mkdir -p /tmp/pacstall
+          sudo chown -R $USER:$USER /tmp/pacstall
       - name: Installing packages with pacstall
         run: | 
           sudo dpkg --add-architecture i386

--- a/.github/workflows/test-package-install.yml
+++ b/.github/workflows/test-package-install.yml
@@ -16,6 +16,7 @@ jobs:
           export PACSTALL_SKIP_NETWORK_CHECK=1
           sudo bash -c "$(wget -q https://git.io/JsADh -O -)"
           sudo apt remove -y axel
+          chmod u+w /tmp/
       - name: Installing packages with pacstall
         run: | 
           sudo dpkg --add-architecture i386

--- a/.github/workflows/test-package-install.yml
+++ b/.github/workflows/test-package-install.yml
@@ -15,6 +15,7 @@ jobs:
         run: |
           export PACSTALL_SKIP_NETWORK_CHECK=1
           sudo bash -c "$(wget -q https://git.io/JsADh -O -)"
+          apt remove -y axel
       - name: Installing packages with pacstall
         run: | 
           sudo dpkg --add-architecture i386


### PR DESCRIPTION
Axel causes the CI to fail downloading the source for a package.

I verified it is axels fault due to the line in the CI, where it say’s `error opening local file`
https://github.com/haileys/axel/blob/8e8eeb0650a097213d1b439e98629dfc6e709af9/axel.c#L178