### PR TITLE
add: `dust-bin`

### DIFF
--- a/packagelist
+++ b/packagelist
@@ -51,6 +51,7 @@ drawio-desktop-deb
 dropbox-deb
 duf-deb
 dunst
+dust-bin
 electronmail-deb
 emacs
 emacs-git

--- a/packages/dust-bin/dust-bin.pacscript
+++ b/packages/dust-bin/dust-bin.pacscript
@@ -4,7 +4,7 @@ pkgdir="${STOWDIR}/${name}"
 version="0.7.5"
 description="A more intuitive version of du in rust"
 url="https://github.com/bootandy/dust/releases/download/v${version}/dust-v${version}-x86_64-unknown-linux-musl.tar.gz"
-breaks="${pkgname}"
+gives="${pkgname}"
 breaks="${pkgname} ${pkgname}-git ${pkgname}-deb ${pkgname}-app"
 hash="6ee34a8b347d58df988c1f796b65a6c56fb5e65d5d2c79ed06c6627228ac4256"
 

--- a/packages/dust-bin/dust-bin.pacscript
+++ b/packages/dust-bin/dust-bin.pacscript
@@ -1,0 +1,34 @@
+name="dust-bin"
+pkgname="dust"
+pkgdir="${STOWDIR}/${name}"
+version="0.7.5"
+description="A more intuitive version of du in rust"
+url="https://github.com/bootandy/dust/releases/download/v${version}/dust-v${version}-x86_64-unknown-linux-musl.tar.gz"
+breaks="${pkgname} ${pkgname}-git ${pkgname}-deb ${pkgname}-app"
+hash="6ee34a8b347d58df988c1f796b65a6c56fb5e65d5d2c79ed06c6627228ac4256"
+
+prepare() {
+  true
+}
+
+build() {
+  true
+}
+
+install() {
+  # Install license
+  sudo install -Dm644 "LICENSE" -t "${pkgdir}/usr/share/licenses/${pkgname}"
+
+  # Install doc
+  sudo install -Dm644 "README.md" -t "${pkgdir}/usr/share/doc/${pkgname}"
+
+  # Install binary
+  sudo install -Dm755 "${pkgname}" "${pkgdir}/usr/bin/${pkgname}"
+}
+
+removescript() {
+  # Remove empty directories
+  sudo rm -rf "/usr/share/licenses/${pkgname}"
+  sudo rm -rf "/usr/share/doc/${pkgname}"
+}
+# vim:set ft=sh ts=2 sw=2 et:

--- a/packages/dust-bin/dust-bin.pacscript
+++ b/packages/dust-bin/dust-bin.pacscript
@@ -1,3 +1,11 @@
+#  __      __________   ______
+# /  \    /  \_____  \ /  __  \
+# \   \/\/   //  ____/ >      <
+#  \        //       \/   --   \
+#   \__/\  / \_______ \______  /
+#        \/          \/      \/
+maintainer="wizard-28 <wiz28@pm.me>"
+
 name="dust-bin"
 pkgname="dust"
 pkgdir="${STOWDIR}/${name}"

--- a/packages/dust-bin/dust-bin.pacscript
+++ b/packages/dust-bin/dust-bin.pacscript
@@ -4,6 +4,7 @@ pkgdir="${STOWDIR}/${name}"
 version="0.7.5"
 description="A more intuitive version of du in rust"
 url="https://github.com/bootandy/dust/releases/download/v${version}/dust-v${version}-x86_64-unknown-linux-musl.tar.gz"
+breaks="${pkgname}"
 breaks="${pkgname} ${pkgname}-git ${pkgname}-deb ${pkgname}-app"
 hash="6ee34a8b347d58df988c1f796b65a6c56fb5e65d5d2c79ed06c6627228ac4256"
 


### PR DESCRIPTION
## Progress
- [x] Edit `packagelist`
- [x] Add initial pacscript (`maintainer`-less)
- [x] Contact devs (https://github.com/bootandy/dust/issues/202)
- [x] Add `maintainer` to pacscript (resolved to `wizard-28`): https://github.com/bootandy/dust/issues/202#issuecomment-997851337