### PR TITLE
upd(brave-browser-deb): `1.32.115` -> `1.33.106`

### DIFF
--- a/packages/brave-browser-deb/brave-browser-deb.pacscript
+++ b/packages/brave-browser-deb/brave-browser-deb.pacscript
@@ -1,8 +1,8 @@
 name="brave-browser-deb"
 gives="brave-browser"
-version="1.32.115"
+version="1.33.106"
 url="https://github.com/brave/${gives}/releases/download/v${version}/${gives}_${version}_amd64.deb"
 description="Brave Browser: Release version of world's most unique, privacy friendly web browser"
-hash="e8363780bc9a3129236443d1f68d618ae145b0bdb66d37aad9237d36ddc30927"
+hash="5d2aa543273a809b617217e6ab6f5de7e3955526b1606ef3a5564d159a65ebbb"
 pacdeps=("brave-keyring-deb")
 maintainer="Zahrun <Zahrun@github.com>"


### PR DESCRIPTION
https://www.bleepingcomputer.com/news/security/google-pushes-emergency-chrome-update-to-fix-zero-day-used-in-attacks/
https://github.com/brave/brave-browser/releases/tag/v1.33.106