### PR TITLE
docs(readme): add link to pacstall repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Pacstall Programs
 
-This is the default repository of pacscripts which pacstall uses to install software. You can fork this repository and add make your own package repository as long as it follows the basic structure:
+This is the default repository of pacscripts which [pacstall](https://github.com/pacstall/pacstall) uses to install software. You can fork this repository and add make your own package repository as long as it follows the basic structure:
 
 ```monospace
 package-repository/


### PR DESCRIPTION
Hi,
This is just a small proposition that in my opinion makes the navigation easier from the packages repo to the manager repo, and might help newcomers.