### PR TITLE
fix(nano):  make and automake edge case

### DIFF
--- a/packages/nano/nano.pacscript
+++ b/packages/nano/nano.pacscript
@@ -4,7 +4,7 @@ minor_version="0"
 version="${major_version}.${minor_version}"
 license="GPL3"
 url="https://www.nano-editor.org/dist/v${major_version}/${name}-${version}.tar.gz"
-build_depends="libncurses-dev groff autoconf automake autopoint gcc gettext git make pkg-config texinfo"
+build_depends="libncurses-dev groff autoconf make automake autopoint gcc gettext git pkg-config texinfo"
 description="GNU Nano"
 hash="3c22971432503c0f84e1c0fbe8a04d35acc131034f8a03fdfdbca77a99208e81"
 


### PR DESCRIPTION
Replace `make` position to avoid wrong first match substitution (`automake -> auto`)