### PR TITLE
add: `tidal-hifi-bin`

### DIFF
--- a/packagelist
+++ b/packagelist
@@ -211,6 +211,7 @@ teams-for-linux-deb
 telegram-bin
 tenacity-git
 thrive-deb
+tidal-hifi-bin
 tmpmail-bin
 tmux
 topgrade-bin

--- a/packages/tidal-hifi-bin/tidal-hifi-bin.pacscript
+++ b/packages/tidal-hifi-bin/tidal-hifi-bin.pacscript
@@ -1,6 +1,6 @@
-name=tidal-hifi-bin
-pkgname=tidal-hifi
-version=2.8.0
+name="tidal-hifi-bin"
+pkgname="tidal-hifi"
+version="2.8.0"
 description="The web version of listen.tidal.com running in electron with hifi support thanks to widevine"
 repology=("project: tidal-hifi" "visiblename: tidal-hifi-bin")
 url="https://github.com/Mastermindzh/tidal-hifi/releases/download/${version}/tidal-hifi-${version}.tar.gz"

--- a/packages/tidal-hifi-bin/tidal-hifi-bin.pacscript
+++ b/packages/tidal-hifi-bin/tidal-hifi-bin.pacscript
@@ -31,8 +31,8 @@ install() {
     # Install the rest of the app
     sudo install -d "${STOWDIR}/${name}/opt/${pkgname}/" "${STOWDIR}/${name}/usr/bin"
 
-    sudo cp -r tidal-hifi-${version}/* ${STOWDIR}/${name}/opt/${pkgname}/
+    sudo cp -r ${SRCDIR}/tidal-hifi-${version}/* ${STOWDIR}/${name}/opt/${pkgname}/
     sudo chmod +x "${STOWDIR}/${name}/opt/${pkgname}/tidal-hifi"
     
-    sudo ln -s "${STOWDIR}/${name}/opt/${pkgname}/tidal-hifi" "${STOWDIR}/${name}/usr/bin/tidal-hifi"
+    sudo ln -s -r "${STOWDIR}/${name}/opt/${pkgname}/tidal-hifi" "${STOWDIR}/${name}/usr/bin/tidal-hifi"
 }

--- a/packages/tidal-hifi-bin/tidal-hifi-bin.pacscript
+++ b/packages/tidal-hifi-bin/tidal-hifi-bin.pacscript
@@ -22,17 +22,17 @@ build() {
 install() {
     # Get icon from github and install it
     wget -q "https://github.com/Mastermindzh/tidal-hifi/raw/master/build/icon.png"
-    sudo install -Dm644 icon.png "${STOWDIR}/${name}/usr/share/pixmaps/${name}.png"
+    sudo install -Dm644 icon.png "${STOWDIR}/${name}/usr/share/pixmaps/${pkgname}.png"
 
     # Get desktop file and install it
     wget -q "https://aur.archlinux.org/cgit/aur.git/plain/tidal-hifi.desktop?h=tidal-hifi-bin" -O tidal-hifi.desktop
     sudo install -Dm644 tidal-hifi.desktop -t "${STOWDIR}/${name}/usr/share/applications"
 
     # Install the rest of the app
-    sudo install -d "${STOWDIR}/${name}/opt/tidal-hifi/" "${STOWDIR}/${name}/usr/bin"
+    sudo install -d "${STOWDIR}/${name}/opt/${pkgname}/" "${STOWDIR}/${name}/usr/bin"
 
-    sudo cp -r tidal-hifi-${version}/* ${STOWDIR}/${name}/opt/${name}/
-    sudo chmod +x "${STOWDIR}/${name}/opt/${name}/tidal-hifi"
+    sudo cp -r tidal-hifi-${version}/* ${STOWDIR}/${name}/opt/${pkgname}/
+    sudo chmod +x "${STOWDIR}/${name}/opt/${pkgname}/tidal-hifi"
     
-    sudo ln -s "${STOWDIR}/${name}/opt/${name}/tidal-hifi" "${STOWDIR}/${name}/usr/bin/tidal-hifi"
+    sudo ln -s "${STOWDIR}/${name}/opt/${pkgname}/tidal-hifi" "${STOWDIR}/${name}/usr/bin/tidal-hifi"
 }

--- a/packages/tidal-hifi-bin/tidal-hifi-bin.pacscript
+++ b/packages/tidal-hifi-bin/tidal-hifi-bin.pacscript
@@ -1,0 +1,38 @@
+name=tidal-hifi-bin
+pkgname=tidal-hifi
+version=2.8.0
+description="The web version of listen.tidal.com running in electron with hifi support thanks to widevine"
+repology=("project: tidal-hifi" "visiblename: tidal-hifi-bin")
+url="https://github.com/Mastermindzh/tidal-hifi/releases/download/${version}/tidal-hifi-${version}.tar.gz"
+hash="cfcbdbcbec8798ef1fc1c0925b966c457eec66480ea0921f22bb6af74dee9506"
+maintainer="Marie Piontek <marie@kaifa.ch>"
+gives="${pkgname}"
+breaks="${pkgname} ${pkgname}-deb ${pkgname}-app ${pkgname}-git"
+
+depends="libxss1 libnss3 libgtk-3-0"
+
+prepare() {
+    true
+}
+
+build() {
+    true
+}
+
+install() {
+    # Get icon from github and install it
+    wget -q "https://github.com/Mastermindzh/tidal-hifi/raw/master/build/icon.png"
+    sudo install -Dm644 icon.png "${STOWDIR}/${name}/usr/share/pixmaps/${name}.png"
+
+    # Get desktop file and install it
+    wget -q "https://aur.archlinux.org/cgit/aur.git/plain/tidal-hifi.desktop?h=tidal-hifi-bin" -O tidal-hifi.desktop
+    sudo install -Dm644 tidal-hifi.desktop -t "${STOWDIR}/${name}/usr/share/applications"
+
+    # Install the rest of the app
+    sudo install -d "${STOWDIR}/${name}/opt/tidal-hifi/" "${STOWDIR}/${name}/usr/bin"
+
+    sudo cp -r tidal-hifi-${version}/* ${STOWDIR}/${name}/opt/${name}/
+    sudo chmod +x "${STOWDIR}/${name}/opt/${name}/tidal-hifi"
+    
+    sudo ln -s "${STOWDIR}/${name}/opt/${name}/tidal-hifi" "${STOWDIR}/${name}/usr/bin/tidal-hifi"
+}

--- a/packages/tidal-hifi-bin/tidal-hifi-bin.pacscript
+++ b/packages/tidal-hifi-bin/tidal-hifi-bin.pacscript
@@ -33,6 +33,6 @@ install() {
 
     sudo cp -r ${SRCDIR}/tidal-hifi-${version}/* ${STOWDIR}/${name}/opt/${pkgname}/
     sudo chmod +x "${STOWDIR}/${name}/opt/${pkgname}/tidal-hifi"
-    
+
     sudo ln -s -r "${STOWDIR}/${name}/opt/${pkgname}/tidal-hifi" "${STOWDIR}/${name}/usr/bin/tidal-hifi"
 }


### PR DESCRIPTION
This would add the AUR package [tidal-hifi-bin](https://aur.archlinux.org/packages/tidal-hifi-bin) previously called tidal-hifi before the change to -bin to pacstall.