### PR TITLE
fix(an-anime-game-launcher-bin): add removescript

### DIFF
--- a/packages/an-anime-game-launcher-bin/an-anime-game-launcher-bin.pacscript
+++ b/packages/an-anime-game-launcher-bin/an-anime-game-launcher-bin.pacscript
@@ -37,3 +37,9 @@ install() {
     sudo install -Dm755 "${SRCDIR}/an-anime-game-launcher.sh" "${STOWDIR}/${name}/usr/bin/${pkgname}"
     sudo install -Dm644 "${SRCDIR}/an-anime-game-launcher.desktop" -t "${STOWDIR}/${name}/usr/share/applications"
 }
+
+removescript() {
+  if ask "Do you want to delete all launcher files(~/.local/share/anime-game-launcher)? This includes configs and the game" Y; then
+    rm -rf ~/.local/share/anime-game-launcher
+  fi
+}


### PR DESCRIPTION
Henry once mentioned this in our discord that the script should ask for removal of the launcher's data folder and I didn't realize until now that librewolf already had a perfectly working example.