### PR TITLE
ci(fix): Assign PR Author as Assignee

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,7 +1,7 @@
 name: "Assign PR Author as Assignee"
 
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, ready_for_review, reopened]
 
 jobs:
@@ -9,6 +9,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: "Assign Author as Assignee"
-      uses: itsOliverBott/assign-pr-author-as-assignee@latest
+      uses: toshimaru/auto-author-assign@v1.5.0
       with:
         token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -11,4 +11,4 @@ jobs:
     - name: "Assign Author as Assignee"
       uses: toshimaru/auto-author-assign@v1.5.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repo-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
I have noticed that it keeps failing to Assign the PR author and replaced it with a more up to date PR assign action while also trying it out on the fork.