### PR TITLE
ci(github): change trigger for labeler and fix title detection

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,8 +1,8 @@
 version: 1
 labels:
 - label: "Update Package"
-  title: "upd(.*"
+  title: "^upd(.*"
 - label: "Package Add"
-  title: "add:.*"
+  title: "^add:.*"
 - label: "remove package"
-  title: "rm:.*"
+  title: "^rm:.*"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,7 +1,7 @@
 name: Label PRs
 
 on:
-- pull_request
+- pull_request_target
 
 jobs:
   build:


### PR DESCRIPTION
Make labeler only trigger on the PR itself and not on every PR commit, Fix the regex for title detection as it was missing the ^