### PR TITLE
ci(github): fix regex for Update Package

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,7 +1,7 @@
 version: 1
 labels:
 - label: "Update Package"
-  title: "^upd(.*"
+  title: "^upd\(.*"
 - label: "Package Add"
   title: "^add:.*"
 - label: "remove package"


### PR DESCRIPTION
( gets detected by regex as the beginning of a group structure without escape stringing it
![image](https://user-images.githubusercontent.com/8841466/166700961-cd878227-f609-4fdc-a82a-740b52f30111.png)
![image](https://user-images.githubusercontent.com/8841466/166701011-41f8e2fb-e3b9-45ee-b227-332a0d29fa06.png)
