### PR TITLE
rm: `torbrowser-launcher-deb`

### DIFF
--- a/packagelist
+++ b/packagelist
@@ -240,7 +240,6 @@ tmpmail-bin
 tmux
 topgrade-bin
 tor
-torbrowser-launcher-deb
 torguard-deb
 touchegg-deb
 treefetch-bin

--- a/packages/torbrowser-launcher-deb/torbrowser-launcher-deb.pacscript
+++ b/packages/torbrowser-launcher-deb/torbrowser-launcher-deb.pacscript
@@ -1,7 +1,0 @@
-name="torbrowser-launcher-deb"
-gives="torbrowser-launcher"
-version="0.3.5-1"
-url="https://github.com/WRM-42/${name}/raw/main/${gives}_${version}_all.deb"
-description="Securely and easily download, verify, install, and launch Tor Browser in Linux."
-hash="4b9ecf3881eb46fb44396e3130305e17cf9c6474114bc2721802283c49919dd1"
-maintainer="WRM-42 <y8bsbahy@anonaddy.me>"


### PR DESCRIPTION
I'm not a big fan of using an unofficial source for security reasons