### PR TITLE
fix(pacstall-gui-git): get rid of moving useless files

### DIFF
--- a/packages/pacstall-gui-git/pacstall-gui-git.pacscript
+++ b/packages/pacstall-gui-git/pacstall-gui-git.pacscript
@@ -21,7 +21,7 @@ build() {
 
 install() {
   sudo install -Dm755 pacstall-gui "${STOWDIR}/${name}/usr/bin/pacstall-gui"
-  sudo mv -f ./settings.sh ./disable-root-check.diff ./change-update-path.diff ./use-patched-pacstall.diff "${STOWDIR}/${name}/usr/lib/pacstall-gui"
+  sudo mv -f ./settings.sh "${STOWDIR}/${name}/usr/lib/pacstall-gui"
   sudo install -Dm755 LICENSE "${STOWDIR}/${name}/usr/share/licenses/pacstall-gui/LICENSE"
   sudo mv -f ./pacstall-gui.desktop "${STOWDIR}/${name}/usr/share/applications"
 }


### PR DESCRIPTION
pacstall-gui-git has removed the use of patch files now.