### PR TITLE
Fix(neovim-git): optimize build

### DIFF
--- a/packages/neovim-git/neovim-git.pacscript
+++ b/packages/neovim-git/neovim-git.pacscript
@@ -16,7 +16,7 @@ prepare() {
 }
 
 build() {
-    make -j$(nproc)
+    make CMAKE_BUILD_TYPE=Release
 }
 
 install() {


### PR DESCRIPTION
1. There are 3 types of builds and the default one is `Debug`, which is the slowest.
2. As recommended by neovim team, there is no need to use `-j` flag, since it will run in parallel anyways.

See: https://github.com/neovim/neovim/wiki/Building-Neovim#building