### PR TITLE
add: `qtile-extras-git`

### DIFF
--- a/packagelist
+++ b/packagelist
@@ -209,6 +209,7 @@ protonvpn-nm-lib
 pycharm-community-bin
 qogir-gtk-theme-bin
 qogir-icon-theme-bin
+qtile-extras-git
 qtile-git
 realvnc-vnc-viewer-deb
 renegate

--- a/packages/qtile-extras-git/qtile-extras-git.pacscript
+++ b/packages/qtile-extras-git/qtile-extras-git.pacscript
@@ -1,0 +1,24 @@
+name="qtile-extras-git"
+pkgname="qtile-extras"
+url="https://github.com/elParaguayo/qtile-extras.git"
+license="MIT"
+description="It is a list of mods developed by elParaguayo for Qtile"
+pacdeps=("qtile-git")
+maintainer="Ruturajn <nanotiruturaj@gmail.com>"
+
+pkgver() {
+  git ls-remote "${url}" main | cut -f1 | cut -c1-8
+}
+version="$(pkgver)"
+
+prepare() {
+  true
+}
+
+build() {
+  true
+}
+
+install() {
+    sudo python3 setup.py install --root="${STOWDIR}/${name}"
+}


### PR DESCRIPTION
- Added `qtile-extras-git` to the list of supported packages.
- Added `qtile-extras-git.pacscript`.
- Updated the `packagelist`.

The package `qtile-extras-git` installs `qtile-git` as a dependency, but I am not sure as to, how to uninstall `qtile-git`, when `$ pacstall -R qtile-extras-git` is called. I was thinking that running `pacstall -R qtile-git` in the `removescript` function, would do the job, is this the right way, if not please let me know how I should do this.

Thanks