### PR TITLE
upd(vscodium-deb): v1.68.1 -> v1.69.0

### DIFF
--- a/packages/vscodium-deb/vscodium-deb.pacscript
+++ b/packages/vscodium-deb/vscodium-deb.pacscript
@@ -1,8 +1,8 @@
 name="vscodium-deb"
 gives="codium"
-version="1.68.1"
-url="https://github.com/VSCodium/vscodium/releases/download/${version}/${gives}_${version}-1655338709_amd64.deb"
+version="1.69.0"
+url="https://github.com/VSCodium/vscodium/releases/download/${version}/${gives}_${version}-1657241063_amd64.deb"
 description="Free/Libre open source software binaries for VSCode"
-hash="32061f288ad830027eaad0185548ef7f3e10ce633b2094953fdfeba1eb8e145f"
+hash="436d0c4c960112d05b716461cbf49411cedc3be49027f0c52ebd1d33279d246c"
 maintainer="WRM-42 <y8bsbahy@anonaddy.me>"
 repology=("project: vscodium")


### PR DESCRIPTION
Seems like the url has changed here as well.