### PR TITLE
fix(bitwarden-deb): change repology

### DIFF
--- a/packages/bitwarden-deb/bitwarden-deb.pacscript
+++ b/packages/bitwarden-deb/bitwarden-deb.pacscript
@@ -7,4 +7,4 @@ url="https://github.com/${gives}/clients/releases/download/desktop-v${version}/B
 description="Open Source Password Manager"
 hash="0262a2fa22d089296625c0a7e40809306c302762f85728683f4c5eb944ee933c"
 maintainer="WRM-42 <y8bsbahy@anonaddy.me>"
-repology=("project: bitwarden-desktop" "repo: funtoo_1.4")
+repology=("project: bitwarden")


### PR DESCRIPTION
It seems that the [bitwarden-desktop repology entry](https://repology.org/project/bitwarden-desktop/versions) is not updated as often as the [bitwarden repology entry](https://repology.org/project/bitwarden/versions) so I have changed the `bitwarden-deb` package to use the latter. Note that this pacstall package appears under the new repology entry (and *not* the old one). I have also checked a few other package repositories to confirm that their packages are for the desktop app (as opposed to the CLI tool or something else related to bitwarden).