### PR TITLE
upd(vscodium-deb): `1.69.0` -> `1.69.1`

### DIFF
--- a/packages/vscodium-deb/vscodium-deb.pacscript
+++ b/packages/vscodium-deb/vscodium-deb.pacscript
@@ -1,8 +1,8 @@
 name="vscodium-deb"
 gives="codium"
-version="1.69.0"
-url="https://github.com/VSCodium/vscodium/releases/download/${version}/${gives}_${version}-1657241063_amd64.deb"
+version="1.69.1"
+url="https://github.com/VSCodium/vscodium/releases/download/${version}/${gives}_${version}-1657672982_amd64.deb"
 description="Free/Libre open source software binaries for VSCode"
-hash="436d0c4c960112d05b716461cbf49411cedc3be49027f0c52ebd1d33279d246c"
+hash="384a4a5fdd1a3d2699dd7fc1eddee25e507f84f6e381c8b6c11b04e182e2ce08"
 maintainer="WRM-42 <y8bsbahy@anonaddy.me>"
 repology=("project: vscodium")


### PR DESCRIPTION
it is seeming like the numbers in the url are changing every time. 