### PR TITLE
add: `arduino-ide-bin`

### DIFF
--- a/packagelist
+++ b/packagelist
@@ -9,6 +9,7 @@ anydesk-deb
 aomp-deb
 appimagelauncher-deb
 ardour-git
+arduino-ide-bin
 awesome-git
 aws-cli-v2-bin
 balena-etcher-electron-deb

--- a/packages/arduino-ide-bin/arduino-ide-bin.pacscript
+++ b/packages/arduino-ide-bin/arduino-ide-bin.pacscript
@@ -1,0 +1,56 @@
+name="arduino-ide-bin"
+pkgname="arduino-ide"
+version="1.8.19"
+repology=("project: arduino")
+maintainer="DismissedGuy <me@mikealmel.ooo>"
+breaks="${pkgname} ${pkgname}-deb ${pkgname}-app ${pkgname}-git"
+url="https://downloads.arduino.cc/arduino-${version}-linux64.tar.xz"
+description="An open-source IDE that makes it easy to write code and upload it to Arduino boards"
+hash="eb68bddc1d1c0120be2fca1350a03ee34531cf37f51847b21210b6e70545bc9b"
+
+prepare() {
+  sudo mkdir -p "${STOWDIR}/${name}/usr/share/${pkgname}/"
+  sudo mkdir -p "${STOWDIR}/${name}/usr/share/applications/"
+  sudo mkdir -p "${STOWDIR}/${name}/usr/share/icons/"
+  sudo mkdir -p "${STOWDIR}/${name}/usr/local/bin/"
+}
+
+build() {
+  true
+}
+
+install() {
+  DEST="${STOWDIR}/${name}"
+
+  # create .desktop from template
+  sed -e "s,<BINARY_LOCATION>,\"${DEST}/usr/share/${pkgname}/arduino\",g" \
+      -e "s,<ICON_NAME>,arduino-arduinoide,g" "lib/desktop.template" \
+      | sudo tee "${DEST}/usr/share/applications/${pkgname}.desktop" > /dev/null
+
+  # register mimetype
+  sudo install -Dm 644 "lib/arduino-arduinoide.xml" -t "${DEST}/usr/share/mime/packages/"
+
+  # install icons / mimetypes
+  for size in 16 24 32 48 64 72 96 128 256; do
+    # mimetypes
+    sudo install -dm 755 "${DEST}/usr/share/icons/hicolor/${size}x${size}/mimetypes"
+    sudo install -Dm 644 "lib/icons/${size}x${size}/apps/arduino.png" "${DEST}/usr/share/icons/hicolor/${size}x${size}/mimetypes/text-x-arduino.png"
+
+    # icons
+    sudo install -dm 755 "${DEST}/usr/share/icons/hicolor/${size}x${size}/apps"
+    sudo install -Dm 644 "lib/icons/${size}x${size}/apps/arduino.png" "${DEST}/usr/share/icons/hicolor/${size}x${size}/apps/arduino-arduinoide.png"
+  done
+
+  # install the program
+  sudo mv ./* "${DEST}/usr/share/${pkgname}/"
+}
+
+postinst() {
+  # link main executable so it is in PATH
+  sudo ln -s "${STOWDIR}/${name}/usr/share/${pkgname}/arduino" "/usr/local/bin/arduino"
+}
+
+removescript() {
+  # remove linked executable
+  sudo rm "/usr/local/bin/arduino"
+}

--- a/packages/arduino-ide-bin/arduino-ide-bin.pacscript
+++ b/packages/arduino-ide-bin/arduino-ide-bin.pacscript
@@ -12,7 +12,6 @@ prepare() {
   sudo mkdir -p "${STOWDIR}/${name}/usr/share/${pkgname}/"
   sudo mkdir -p "${STOWDIR}/${name}/usr/share/applications/"
   sudo mkdir -p "${STOWDIR}/${name}/usr/share/icons/"
-  sudo mkdir -p "${STOWDIR}/${name}/usr/local/bin/"
 }
 
 build() {

--- a/packages/arduino-ide-bin/arduino-ide-bin.pacscript
+++ b/packages/arduino-ide-bin/arduino-ide-bin.pacscript
@@ -48,7 +48,7 @@ postinst() {
   # link main executable so it is in PATH
   sudo ln -s "${STOWDIR}/${name}/usr/share/${pkgname}/arduino" "/usr/local/bin/arduino"
 
-  fancy_message info "Please run the following command to authorize access to the Arduino's serial interface: \"sudo usermod -aG uucp dialout ${USER}\". You might have to log out and in again for the changes to take effect."
+  fancy_message info "Please run the following command to authorize access to the Arduino's serial interface: \"sudo usermod -aG uucp dialout ${USER:-$(whoami)}\". You might have to log out and in again for the changes to take effect."
 }
 
 removescript() {

--- a/packages/arduino-ide-bin/arduino-ide-bin.pacscript
+++ b/packages/arduino-ide-bin/arduino-ide-bin.pacscript
@@ -48,6 +48,8 @@ install() {
 postinst() {
   # link main executable so it is in PATH
   sudo ln -s "${STOWDIR}/${name}/usr/share/${pkgname}/arduino" "/usr/local/bin/arduino"
+
+  fancy_message info "Please run the following command to authorize access to the Arduino's serial interface: \"sudo usermod -aG uucp dialout ${USER}\". You might have to log out and in again for the changes to take effect."
 }
 
 removescript() {

--- a/packages/arduino-ide-bin/arduino-ide-bin.pacscript
+++ b/packages/arduino-ide-bin/arduino-ide-bin.pacscript
@@ -41,7 +41,7 @@ install() {
   done
 
   # install the program
-  sudo mv ./* "${DEST}/usr/share/${pkgname}/"
+  sudo cp -R ./* "${DEST}/usr/share/${pkgname}/"
 }
 
 postinst() {

--- a/packages/arduino-ide-bin/arduino-ide-bin.pacscript
+++ b/packages/arduino-ide-bin/arduino-ide-bin.pacscript
@@ -46,7 +46,7 @@ install() {
 
 postinst() {
   # link main executable so it is in PATH
-  sudo ln -s "${STOWDIR}/${name}/usr/share/${pkgname}/arduino" "/usr/local/bin/arduino"
+  sudo ln -sf "${STOWDIR}/${name}/usr/share/${pkgname}/arduino" "/usr/local/bin/arduino"
 
   fancy_message info "Please run the following command to authorize access to the Arduino's serial interface: \"sudo usermod -aG uucp dialout ${USER:-$(whoami)}\". You might have to log out and in again for the changes to take effect."
 }


### PR DESCRIPTION
Adds `arduino-ide-bin`, version `1.8.19`.

I considered adding commands to `postinst` to add the user to the "uucp" and "dialout" groups, which is usually required to access the Arduino's serial interface as a regular user (also see [this](https://playground.arduino.cc/Linux/All/#Permission)). However, since this is user-specific and the program is installed system-wide, I decided against this.
I can still add it if desired, but the IDE should also point users to the article above if it detects a permission issue, so I'm not sure if it's necessary.