### PR TITLE
upd(discord-canary): `0.0.136` -> `0.0.137`

### DIFF
--- a/packages/discord-canary/discord-canary.pacscript
+++ b/packages/discord-canary/discord-canary.pacscript
@@ -1,11 +1,11 @@
 name="discord-canary"
 repology=("project: discord-canary")
-version="0.0.136"
+version="0.0.137"
 maintainer="Warofzen <warofzen1@pm.me>"
 url="https://dl-canary.discordapp.net/apps/linux/${version}/${name}-${version}.tar.gz"
 depends="libc6 libasound2 libatomic1 libgconf-2-4 libnotify4 libnspr4 libnss3 libstdc++6 libxss1 libxtst6 libayatana-appindicator1 libc++1"
 description="Chat for Communities and Friends - Unstable"
-hash="3ab1a0e235f389eb0706140e47144437fc2aefbe9180d19a4f28c9355e294805"
+hash="76b78a3b6c810cfe78ed562e273881842dac2dda5b3367dc2b96f179db34cd44"
 
 prepare() {
         sudo mkdir -p /usr/src/pacstall/${name}/usr/share/${name}/
@@ -19,6 +19,6 @@ build() {
 
 install() {
         sudo install -Dm755 discord-canary.desktop "${STOWDIR}/${name}/usr/share/applications/discord-canary.desktop"
-        sudo install -Dm755 discord.png "${STOWDIR}/${name}/usr/share/icons/discord.png"
+        sudo install -Dm755 discord.png "${STOWDIR}/${name}/usr/share/icons/discord-canary.png"
         sudo cp -R ./* "${STOWDIR}/${name}/usr/share/${name}/"
 }


### PR DESCRIPTION
Also fixes incorrect naming of the icon png, causing the desktop icon to be missing.