### PR TITLE
add: `zap`

### DIFF
--- a/packages/zap/zap.pacscript
+++ b/packages/zap/zap.pacscript
@@ -2,6 +2,7 @@ name="zap"
 version="2.2.1"
 depends="curl grep jq wget"
 url="https://github.com/srevinsaju/zap/releases/download/v2.2.1/zap-amd64"
+hash="4972edd5da1be5c5dd2fa14619c7068b09fd9dc31c1feea50ed564cdb14df6bc"
 description="A delightful AppImage package manager"
 maintainer="srevinsaju <hello@srev.in>"
 

--- a/packages/zap/zap.pacscript
+++ b/packages/zap/zap.pacscript
@@ -1,6 +1,7 @@
 name="zap"
 version="2.2.1"
 depends="curl grep jq wget"
+url="https://github.com/srevinsaju/zap/releases/download/v2.2.1/zap-amd64"
 description="A delightful AppImage package manager"
 maintainer="srevinsaju <hello@srev.in>"
 

--- a/packages/zap/zap.pacscript
+++ b/packages/zap/zap.pacscript
@@ -1,4 +1,6 @@
 name="zap"
+pkgname="zap"
+repology=("project: zap")
 version="2.2.1"
 depends="curl grep jq wget"
 url="https://github.com/srevinsaju/zap/releases/download/v2.2.1/zap-amd64"

--- a/packages/zap/zap.pacscript
+++ b/packages/zap/zap.pacscript
@@ -16,7 +16,7 @@ build() {
 }
 
 install() {
-        curl https://raw.githubusercontent.com/srevinsaju/zap/main/install.sh | sudo bash -s
+        sudo cp zap-amd65 "$pkgdir/usr/bin/zap"
 }
 
 removescript() {

--- a/packages/zap/zap.pacscript
+++ b/packages/zap/zap.pacscript
@@ -1,6 +1,6 @@
 name="zap"
 version="2.2.1"
-build_depends="curl grep jq wget"
+depends="curl grep jq wget"
 description="A delightful AppImage package manager"
 maintainer="srevinsaju <hello@srev.in>"
 

--- a/packages/zap/zap.pacscript
+++ b/packages/zap/zap.pacscript
@@ -17,5 +17,7 @@ build() {
 }
 
 install() {
-	sudo cp zap-amd65 "$pkgdir/usr/bin/zap"
+	sudo mkdir -p "$pkgdir/usr/bin"
+	sudo cp zap-amd64 "$pkgdir/usr/bin/zap"
+	sudo chmod +x "$pkgdir/usr/bin/zap"
 }

--- a/packages/zap/zap.pacscript
+++ b/packages/zap/zap.pacscript
@@ -1,0 +1,22 @@
+name="zap"
+version="2.2.1"
+build_depends="curl grep jq wget"
+description="A delightful AppImage package manager"
+maintainer="srevinsaju <hello@srev.in>"
+
+prepare() {
+        true
+}
+
+# doesn't need to be built
+build() {
+        true
+}
+
+install() {
+        curl https://raw.githubusercontent.com/srevinsaju/zap/main/install.sh | sudo bash -s
+}
+
+removescript() {
+          rm install.sh
+}

--- a/packages/zap/zap.pacscript
+++ b/packages/zap/zap.pacscript
@@ -18,7 +18,3 @@ build() {
 install() {
         sudo cp zap-amd65 "$pkgdir/usr/bin/zap"
 }
-
-removescript() {
-          rm install.sh
-}

--- a/packages/zap/zap.pacscript
+++ b/packages/zap/zap.pacscript
@@ -9,15 +9,15 @@ description="A delightful AppImage package manager"
 maintainer="srevinsaju <hello@srev.in>"
 
 prepare() {
-	true
+    true
 }
 
 build() {
-	true
+    true
 }
 
 install() {
-	sudo mkdir -p "$pkgdir/usr/bin"
-	sudo cp zap-amd64 "$pkgdir/usr/bin/zap"
-	sudo chmod +x "$pkgdir/usr/bin/zap"
+    sudo mkdir -p "$pkgdir/usr/bin"
+    sudo cp zap-amd64 "$pkgdir/usr/bin/zap"
+    sudo chmod +x "$pkgdir/usr/bin/zap"
 }

--- a/packages/zap/zap.pacscript
+++ b/packages/zap/zap.pacscript
@@ -9,14 +9,13 @@ description="A delightful AppImage package manager"
 maintainer="srevinsaju <hello@srev.in>"
 
 prepare() {
-        true
+	true
 }
 
-# doesn't need to be built
 build() {
-        true
+	true
 }
 
 install() {
-        sudo cp zap-amd65 "$pkgdir/usr/bin/zap"
+	sudo cp zap-amd65 "$pkgdir/usr/bin/zap"
 }


### PR DESCRIPTION
Add initial pacstall script for zap appimage package manager. Related to [this issue](https://github.com/srevinsaju/zap/issues/82).

The script is very basic and just relies on the curl-based shell script that [zap](https://github.com/srevinsaju/zap) itself uses to setup and install itself.