### PR TITLE
upd(topgrade-bin): `9.0.1` -> `9.1.0`

### DIFF
--- a/packages/topgrade-bin/topgrade-bin.pacscript
+++ b/packages/topgrade-bin/topgrade-bin.pacscript
@@ -1,9 +1,9 @@
 name="topgrade-bin"
 pkgname="topgrade"
-version="9.0.1"
-url="https://github.com/r-darwish/topgrade/releases/download/v${version}/topgrade-v${version}-x86_64-unknown-linux-gnu.tar.gz"
+version="9.1.0"
+url="https://github.com/topgrade-rs/topgrade/releases/download/v${version}/topgrade-rs"
 description="Upgrades everything on your system"
-hash="f218bf49c64bad6e1cea33f191e849ba1f20309bfd59e7658412d32bd0626572"
+hash="9eb2c499d5028d373989df487aaf5b6bfb2d419c5736018cd45a85ad3aa43518"
 breaks="${pkgname} ${pkgname}-deb ${pkgname}-app ${pkgname}-git"
 gives="${pkgname}"
 repology=("project: ${pkgname}")
@@ -17,5 +17,6 @@ build() {
 }
 
 install() {
+  mv "${pkgname}-rs" "${pkgname}"
   sudo install -Dm755 "${pkgname}" -t "${STOWDIR}/${name}/usr/bin"
 }


### PR DESCRIPTION
https://github.com/r-darwish/topgrade was archived
https://github.com/topgrade-rs/topgrade is the community effort to keep maintaining the project

In this MR, I rename the executable from topgrade-rs to topgrade
An other option would be to create a separate new package topgrade-rs-bin
Yet an other option is to change the name of this package to topgrade-rs-bin and change it in the packagelist but I don't know how well will pacstall manage this for users