### PR TITLE
add: `libicu71-deb`

### DIFF
--- a/packagelist
+++ b/packagelist
@@ -157,6 +157,7 @@ lbry-deb
 lemonbar-xft-git
 lf-bin
 libcutefish-git
+libicu71-deb
 libndi4-deb
 libresprite-git
 libressl

--- a/packages/libicu71-deb/libicu71-deb
+++ b/packages/libicu71-deb/libicu71-deb
@@ -1,0 +1,7 @@
+name="libicu71-deb"
+gives="libicu71"
+version="71.1"
+url="http://archive.ubuntu.com/ubuntu/pool/main/i/icu/libicu71_71.1-3ubuntu1_amd64.deb"
+description="International Components for Unicode"
+hash="46f5c6cd9cf65ec47927d155b28a4f747701faf0cc1aa0faa717a4ced0c921df"
+maintainer="Zahrun <Zahrun@github.com>"


### PR DESCRIPTION
As a dependency for fsearch-deb in jammy https://github.com/pacstall/pacstall-programs/pull/1712