### PR TITLE
fix(rhino-linux-xfce4-config): don't remove extra files

### DIFF
--- a/packages/rhino-linux-xfce4-config/rhino-linux-xfce4-config.pacscript
+++ b/packages/rhino-linux-xfce4-config/rhino-linux-xfce4-config.pacscript
@@ -11,8 +11,7 @@ version="$(pkgver)"
 url="https://github.com/rhino-linux/dotfiles/archive/${version}.tar.gz"
 
 prepare() {
-  # Is invalid as it contains sysmlinks to /home/httpllamz
-  rm -rf ./xfce4/desktop
+  true
 }
 
 build() {


### PR DESCRIPTION
This issue is being fixed upstream so this isn't need and it was failing (?) for some reason despite it being forced.