### PR TITLE
fix & upd(freetube-deb): `0.17.1` -> `0.18.0`

### DIFF
--- a/packages/freetube-deb/freetube-deb.pacscript
+++ b/packages/freetube-deb/freetube-deb.pacscript
@@ -1,7 +1,8 @@
 name="freetube-deb"
 gives="freetube"
-version="0.17.1"
+version="0.18.0"
 url="https://github.com/FreeTubeApp/FreeTube/releases/download/v${version}-beta/${gives}_${version}_amd64.deb"
 description="An Open Source YouTube app for privacy."
+repology=("project: freetube")
 hash="0abdf750e2589a8918bb3f04bc72e358f32f699793ef703fbb74c04c4ef783af"
 maintainer="WRM-42 <y8bsbahy@anonaddy.me>"

--- a/packages/freetube-deb/freetube-deb.pacscript
+++ b/packages/freetube-deb/freetube-deb.pacscript
@@ -4,5 +4,5 @@ version="0.18.0"
 url="https://github.com/FreeTubeApp/FreeTube/releases/download/v${version}-beta/${gives}_${version}_amd64.deb"
 description="An Open Source YouTube app for privacy."
 repology=("project: freetube")
-hash="0abdf750e2589a8918bb3f04bc72e358f32f699793ef703fbb74c04c4ef783af"
+hash="3ffaaa6b7883c55fa0da5a726e0249389cca435cb37b4af192262158bed0baa8"
 maintainer="WRM-42 <y8bsbahy@anonaddy.me>"


### PR DESCRIPTION
Added Repology info for easy update, and updated it to latest beta 0.18.0