### PR TITLE
fix(discord-canary): Temporarily restrict repology to AUR

### DIFF
--- a/packages/discord-canary/discord-canary.pacscript
+++ b/packages/discord-canary/discord-canary.pacscript
@@ -1,5 +1,5 @@
 name="discord-canary"
-repology=("project: discord-canary")
+repology=("project: discord-canary" "repo: aur")
 version="0.0.148"
 maintainer="DismissedGuy <me@mikealmel.ooo>"
 url="https://dl-canary.discordapp.net/apps/linux/${version}/${name}-${version}.tar.gz"


### PR DESCRIPTION
Temporarily restricts repology information to the AUR to mitigate https://github.com/pacstall/website/issues/228