### PR TITLE
upd(rhino-pkg-git): add versioning (`0.0.2`)

### DIFF
--- a/packages/rhino-pkg-git/rhino-pkg-git.pacscript
+++ b/packages/rhino-pkg-git/rhino-pkg-git.pacscript
@@ -8,7 +8,7 @@ maintainer="Henryws <hwengerstickel@pm.me>"
 pkgver() {
     git ls-remote "${url}" master | cut -f1 | cut -c1-8
 }
-version="$(pkgver)"
+version="0.0.2-$(pkgver)"
 
 install() {
     sudo DESTDIR="${pkgdir}" make install


### PR DESCRIPTION
just the git tag didnt tell you what version of rhino-pkg you were using