### PR TITLE
add: `muse-hub`

### DIFF
--- a/packagelist
+++ b/packagelist
@@ -208,6 +208,7 @@ moka-icon-theme
 ms-teams-deb
 mullvad-vpn-beta-deb
 mullvad-vpn-deb
+muse-hub-deb
 mutt-wizard
 nala-deb
 nano

--- a/packages/muse-hub-deb/muse-hub-deb.pacscript
+++ b/packages/muse-hub-deb/muse-hub-deb.pacscript
@@ -1,0 +1,16 @@
+name="muse-hub-deb"
+pkgname="muse-hub"
+repology=("project: muse-hub")
+version="1.0.1.451"
+url="https://pub-c7a32e5b5d834ec9aeef400105452a42.r2.dev/Muse_Hub.deb"
+depends="icu-devtools"
+gives="muse-hub"
+description="Manage MuseScore Libraries"
+maintainer="Rémy Huet <remy.huet@hds.utc.fr>"
+hash="0896fd96d72cb18102c2436794caffadd67382d5377b84468a514601847cc3e9"
+provides=('muse-hub' 'muse-hub-service')
+
+removescript() {
+    # This is the default place where muse-hub stores dowloaded sounds
+    sudo rm -rf /srv/muse-hub
+}


### PR DESCRIPTION
First, thank you for this great tool !
I'd like to add MuseScore (a great free music edition tool) to pacstall as it is only present as 2.x and 3.4.x in apt, where last version is 4.X with great improvements.
`muse-hub` would be an optional dependency of MuseScore.

Please note that I added `icu-devtools` as a dependency because `muse-hub` seems to need `libicu`.
However, this library is only provided along with a version number in apt, and that depends on the ubuntu/debian version.
I noticed that there is a `libicu71-deb` package in pacstall. Would it be better to use it ?

Moreover, I'd like some help with the `removescript`: despite the `rm -rf` I did in it, the directory `/srv/muse-hub` still exists after uninstall (I tried using both `apt remove` and `pacstall -R`)

Thanks!