### PR TITLE
add: `libssl1.1-deb`

### DIFF
--- a/packagelist
+++ b/packagelist
@@ -175,6 +175,7 @@ libresprite-git
 libressl
 librewolf-app
 librewolf-deb
+libssl1.1-deb
 libxapp1-deb
 linked-deb
 linux-headers-deb

--- a/packages/libssl1.1-deb/libssl1.1-deb.pacscript
+++ b/packages/libssl1.1-deb/libssl1.1-deb.pacscript
@@ -2,16 +2,11 @@ name="libssl1.1-deb"
 pkgname="libssl1.1"
 description="Old version of libssl (for legacy dependencies)"
 maintainer="Rémy Huet <remy.huet@hds.utc.fr>"
-
 repology=("project: libssl1.1")
 version="1.1.1"
-
 url="http://security.ubuntu.com/ubuntu/pool/main/o/openssl/libssl1.1_1.1.1f-1ubuntu2.17_amd64.deb"
 hash="a74ccc29b5ac5cde36f00eb2a6a621e1240cd150cbbecedfecd6925b66bdafa0"
-
 depends="debconf libc6"
-
 replace="libssl1.1"
 gives="libssl1.1"
-
 incompatible=('ubuntu:focal' 'debian:stretch' 'debian:buster' 'debian:bullseye')

--- a/packages/libssl1.1-deb/libssl1.1-deb.pacscript
+++ b/packages/libssl1.1-deb/libssl1.1-deb.pacscript
@@ -1,0 +1,17 @@
+name="libssl1.1-deb"
+pkgname="libssl1.1"
+description="Old version of libssl (for legacy dependencies)"
+maintainer="Rémy Huet <remy.huet@hds.utc.fr>"
+
+repology=("project: libssl1.1")
+version="1.1.1"
+
+url="http://security.ubuntu.com/ubuntu/pool/main/o/openssl/libssl1.1_1.1.1f-1ubuntu2.17_amd64.deb"
+hash="a74ccc29b5ac5cde36f00eb2a6a621e1240cd150cbbecedfecd6925b66bdafa0"
+
+depends="debconf libc6"
+
+replace="libssl1.1"
+gives="libssl1.1"
+
+incompatible=('ubuntu:focal' 'debian:stretch' 'debian:buster' 'debian:bullseye')


### PR DESCRIPTION
Still on my MusesScore stuff, `libssl.so.1.1` is required to run but not available on ubuntu since 22.04.
This pacscript provides `libssl1.1` from ubuntu 20.04, and does not seem to collide with `libssl3` package from newer versions of ubuntu