### PR TITLE
fix(polybar): fix build logic

### DIFF
--- a/packages/polybar/polybar.pacscript
+++ b/packages/polybar/polybar.pacscript
@@ -19,7 +19,7 @@ repology=("project: polybar")
 
 build() {
   mkdir build && cd build
-  cmake .. 
+  cmake ..
   make -j"$(nproc)"
 }
 

--- a/packages/polybar/polybar.pacscript
+++ b/packages/polybar/polybar.pacscript
@@ -17,16 +17,13 @@ optdepends=("libxcb-xkb-dev: xkeyboard"
   "libnl-genl-3-dev: network")
 repology=("project: polybar")
 
-prepare() {
-  mkdir build
-  cd build
-}
-
 build() {
-  cmake ..
+  mkdir build && cd build
+  cmake .. 
   make -j"$(nproc)"
 }
 
 install() {
+  cd build/
   sudo make install DESTDIR="${pkgdir}"
 }


### PR DESCRIPTION
I was getting the following error with the current pacsript implementation:

```
[+] INFO: Extracting polybar-3.6.3.tar.gz
[+] INFO: Running functions
	[>] Running prepare
	[>] Running build
CMake Error: The source directory "/tmp/pacstall" does not appear to contain CMakeLists.txt.
Specify --help for usage, or press the help button on the CMake GUI.
make: *** No targets specified and no makefile found.  Stop.
	[!] ERROR: Could not build polybar properly
dpkg: warning: ignoring request to remove polybar which isn't installed
[+] INFO: Cleaning up
```

I fixed it and successfully installed the package with my proposed changes.

Please let me know if those changes are okay or need improvements.