### PR TITLE
fix: latte-dock-git dependencies

### DIFF
--- a/packages/latte-dock-git/latte-dock-git.pacscript
+++ b/packages/latte-dock-git/latte-dock-git.pacscript
@@ -11,8 +11,9 @@ maintainer="wizard-28 <wiz28@pm.me>"
 name="latte-dock-git"
 pkgname="latte-dock"
 description="Replacement dock for Plasma desktops, providing an elegant and intuitive experience for your tasks and plasmoids"
-url="https://github.com/KDE/latte-dock.git"
-build_depends="cmake extra-cmake-modules qtdeclarative5-dev libqt5x11extras5-dev libkf5iconthemes-dev libkf5plasma-dev libkf5windowsystem-dev libkf5declarative-dev libkf5xmlgui-dev libkf5activities-dev build-essential libxcb-util-dev libkf5wayland-dev git gettext libkf5archive-dev libkf5notifications-dev libxcb-util0-dev libsm-dev libkf5crash-dev libkf5newstuff-dev libxcb-shape0-dev libxcb-randr0-dev libx11-dev libx11-xcb-dev kirigami2-dev libwayland-dev libwayland-client0 plasma-wayland-protocols libqt5waylandclient5-dev qtwayland5-dev-tools python3-pip"
+url="https://invent.kde.org/plasma/latte-dock.git"
+build_depends="cmake extra-cmake-modules qtdeclarative5-dev libqt5x11extras5-dev libkf5iconthemes-dev libkf5plasma-dev libkf5windowsystem-dev libkf5declarative-dev libkf5xmlgui-dev libkf5activities-dev build-essential libxcb-util-dev libkf5wayland-dev git gettext libkf5archive-dev libkf5notifications-dev libxcb-util0-dev libsm-dev libkf5crash-dev libkf5newstuff-dev libxcb-shape0-dev libxcb-randr0-dev libx11-dev libx11-xcb-dev kirigami2-dev libwayland-dev libwayland-client0 plasma-wayland-protocols libqt5waylandclient5-dev qtwayland5-dev-tools python3-pip plasma-workspace-dev"
+depends="plasma-workspace plasma-desktop"
 breaks="${pkgname} ${pkgname}-bin"
 incompatible=("debian:bullseye")
 


### PR DESCRIPTION
Add dependency on plasma-workspace and plasma-desktop
If installed in a DE different from Plasma, and build_depends removed after installation, latte-dock will fail to run.