### PR TITLE
upd(wezterm-bin): `20230326-111934-3666303c` -> `20230408-112425-69ae8472`

### DIFF
--- a/packages/wezterm-bin/wezterm-bin.pacscript
+++ b/packages/wezterm-bin/wezterm-bin.pacscript
@@ -1,10 +1,10 @@
 name="wezterm-bin"
 pkgname="wezterm"
 gives="wezterm"
-version="20230326-111934-3666303c"
+version="20230408-112425-69ae8472"
 description="A GPU-accelerated cross-platform terminal emulator and multiplexer written by @wez and implemented in Rust"
 url="https://github.com/wez/wezterm/releases/download/${version}/wezterm-${version}.Ubuntu22.04.tar.xz"
-hash="636428e0faabd230f3be931131e47c708b1e0451ccce7a80e281346923c9b089"
+hash="a1a0737438a4af9882139da0d78ffc0d390132db5a37b703aec8ef2b5c252370"
 breaks="${pkgname}-app"
 repology=("project: wezterm")
 maintainer="smokeythemonkey <smokeythemonkey@posteo.net>"


### PR DESCRIPTION
Updated WezTerm to the latest version (Hopefully everything is correct)