### PR TITLE
fix(ci): remove based on installed packages

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -96,16 +96,9 @@ jobs:
           export SUDO_USER=$USER
           export DEBIAN_FRONTEND=noninteractive
           export GITHUB_ACTIONS=true
-          for changed_file in ${{ steps.files.outputs.added_modified }}; do
-            if [[ ${changed_file} == *".pacscript" ]]; then
-              pacscript_file=`basename "${changed_file}"`
-              package_name="${pacscript_file/.pacscript/ }"
-              package_dir=`dirname "${changed_file}"`
-              echo "Running pacstall -R for ${package_name}..."
-              pushd ${package_dir}
-              pacstall --disable-prompts -R ${package_name} || exit 1
-              popd
-            fi
+          for changed_file in $(pacstall -L); do
+              echo "Running pacstall -R for ${changed_file}..."
+              pacstall --disable-prompts -R ${changed_file} || exit 1
           done
         shell: sudo -E -u dio bash {0}
         env:
@@ -196,16 +189,9 @@ jobs:
           export SUDO_USER=$USER
           export DEBIAN_FRONTEND=noninteractive
           export GITHUB_ACTIONS=true
-          for changed_file in ${{ steps.files.outputs.added_modified }}; do
-            if [[ ${changed_file} == *".pacscript" ]]; then
-              pacscript_file=`basename "${changed_file}"`
-              package_name="${pacscript_file/.pacscript/ }"
-              package_dir=`dirname "${changed_file}"`
-              echo "Running pacstall -R for ${package_name}..."
-              pushd ${package_dir}
-              pacstall --disable-prompts -R ${package_name} || exit 1
-              popd
-            fi
+          for changed_file in $(pacstall -L); do
+              echo "Running pacstall -R for ${changed_file}..."
+              pacstall --disable-prompts -R ${changed_file} || exit 1
           done
         shell: sudo -E -u dio bash {0}
         env:


### PR DESCRIPTION
If a package is removed by `replace` for example, the remove step will fail because it already has been removed. This PR makes the CI remove based on actually installed packages.