### PR TITLE
chan(maitreya8-deb): change pkgname for repology

### DIFF
--- a/packages/maitreya8-deb/maitreya8-deb.pacscript
+++ b/packages/maitreya8-deb/maitreya8-deb.pacscript
@@ -1,6 +1,6 @@
 name="maitreya8-deb"
 repology=("project: maitreya")
-pkgname="maitreya8"
+pkgname="maitreya"
 version="8.0.1b"
 url="https://github.com/martin-pe/${pkgname}/releases/download/v${version}/${pkgname}_${version}_amd64.deb"
 depends=("libwxsqlite3-3.0-0" "wx-common wx3.0-i18n")


### PR DESCRIPTION
Is it correct that this change would move pacstall to maitreya package in repology?
We are the only repo which has it under maitreya8 https://repology.org/project/maitreya8/versions
Whereas all other repos have it under maitreya https://repology.org/project/maitreya/versions