### PR TITLE
fix: `vscode-insiders-deb`

### DIFF
--- a/packages/vscode-insiders-deb/vscode-insiders-deb.pacscript
+++ b/packages/vscode-insiders-deb/vscode-insiders-deb.pacscript
@@ -1,7 +1,8 @@
 name="vscode-insiders-deb"
 arch=("amd64" "arm64" "armhf")
 gives="code-insiders"
-version="1.80.0"
+version="1.80.0-insiders"
+pkgversion="1.80.0"
 homepage="https://code.visualstudio.com/"
 description="lightweight but powerful source code editor"
 project=("project: vscode-insiders")
@@ -9,16 +10,16 @@ maintainer="Diegiwg <diegiwg@gmail.com>"
 
 case "${CARCH}" in
   amd64)
-    url="https://packages.microsoft.com/repos/code/pool/main/c/code-insiders/code-insiders_${version}-1686808276_amd64.deb"
-    hash="59de6c1ebd99db65639acbf47da59e94a156cd7b5ae5abd960a3d932593c16dd"
+    url="https://packages.microsoft.com/repos/code/pool/main/c/code-insiders/code-insiders_${pkgversion}-1686909910_amd64.deb"
+    hash="ebf2771db5117f3cbe6de4520398f1b8f40be5be194a0e0546c41e7dc64be996"
     ;;
   arm64)
-    url="https://packages.microsoft.com/repos/code/pool/main/c/code-insiders/code-insiders_${version}-1686808335_arm64.deb"
-    hash="7d9f52f5072b37427d3e4df3d74157522b953dba48688a51a9466da1c2669db6"
+    url="https://packages.microsoft.com/repos/code/pool/main/c/code-insiders/code-insiders_${pkgversion}-1686910022_arm64.deb"
+    hash="643ececd339ae42720c23717e13a1b7d1b2dccc41f624d0e25d68bfe3ecaeb95"
     ;;
   armhf)
-    url="https://packages.microsoft.com/repos/code/pool/main/c/code-insiders/code-insiders_${version}-1686807634_armhf.deb"
-    hash="7e4245a22f8d528654ffc368bee1648f5e49b39f87c58a4037e70a622b83ae1b"
+    url="https://packages.microsoft.com/repos/code/pool/main/c/code-insiders/code-insiders_${pkgversion}-1686909311_armhf.deb"
+    hash="c4edc7669955b52843612d9fd1942fa8aff5a8503df25bb74ea87be84d65d575"
     ;;
   *) return 1 ;;
 esac


### PR DESCRIPTION
I needed to duplicate the variable related to the version, because, based on the [repology: vscode](https://repology.org/project/vscode/versions), the `insiders` versions of vscode, have the `-insiders` suffix, which is not compatible with the **.debs** download url.