### PR TITLE
upd(rhino{-pine,-server,}-core): `2023.1-beta5-2` -> `2023.1-beta6-0`

### DIFF
--- a/packages/rhino-core/rhino-core.pacscript
+++ b/packages/rhino-core/rhino-core.pacscript
@@ -1,12 +1,11 @@
 name="rhino-core"
 url="https://github.com/oklopfer/debs/raw/master/empty.tar.xz"
-pacdeps=("unicorn-desktop-git" "rhino-kvantum-theme-git" "rhino-plymouth-theme-git" "rhino-pkg-git" "rhino-neofetch-git")
-depends=("unicorn-desktop" "rhino-kvantum-theme" "rhino-plymouth-theme" "rhino-pkg" "rhino-neofetch")
+pacdeps=("unicorn-desktop-git" "rhino-kvantum-theme-git" "rhino-plymouth-theme-git" "rhino-pkg-git" "rhino-neofetch-git" "rhino-system-git")
 description="Transitional package to provide all core Rhino Linux software"
 maintainer="Oren Klopfer <oren@taumoda.com>"
 replace=("rhino-pine-core" "rhino-server-core")
-production="2023.1-beta5"
-version="${production}-2"
+production="2023.1-beta6"
+version="${production}-0"
 style="(mainline)"
 branch="devel"
 postinst() {

--- a/packages/rhino-pine-core/rhino-pine-core.pacscript
+++ b/packages/rhino-pine-core/rhino-pine-core.pacscript
@@ -1,11 +1,11 @@
 name="rhino-pine-core"
 url="https://github.com/oklopfer/debs/raw/master/empty.tar.xz"
-pacdeps=("xfce4-settings-pine-git" "unicorn-mobile-git" "rhino-kvantum-theme-git" "rhino-plymouth-theme-git" "rhino-pkg-git" "rhino-neofetch-git" "u-boot-mobian-deb")
+pacdeps=("xfce4-settings-pine-git" "unicorn-mobile-git" "rhino-kvantum-theme-git" "rhino-plymouth-theme-git" "rhino-pkg-git" "rhino-neofetch-git" "rhino-system-git" "u-boot-mobian-deb" "mobile-usb-networking-deb")
 description="Transitional package to provide all core Rhino Linux Mobile software"
 maintainer="Oren Klopfer <oren@taumoda.com>"
 replace=("rhino-core" "rhino-server-core")
-production="2023.1-beta5"
-version="${production}-2"
+production="2023.1-beta6"
+version="${production}-0"
 style="(mobile)"
 branch="devel"
 postinst() {

--- a/packages/rhino-server-core/rhino-server-core.pacscript
+++ b/packages/rhino-server-core/rhino-server-core.pacscript
@@ -4,8 +4,8 @@ pacdeps=("rhino-pkg-git" "rhino-neofetch-git")
 description="Transitional package to provide minimal core Rhino Linux software"
 maintainer="Oren Klopfer <oren@taumoda.com>"
 replace=("rhino-core" "rhino-pine-core")
-production="2023.1-beta5"
-version="${production}-2"
+production="2023.1-beta6"
+version="${production}-0"
 style="(server)"
 branch="devel"
 postinst() {


### PR DESCRIPTION
Notable changes:
`core` and `pine-core` now have rhino-system as a pacdep
`pine-core` now has mobile-usb-networking as a pacdep 