### PR TITLE
upd(megasync-deb): `4.9.4-3.1` -> `4.9.5-1.1`

### DIFF
--- a/packages/megasync-deb/megasync-deb.pacscript
+++ b/packages/megasync-deb/megasync-deb.pacscript
@@ -1,8 +1,8 @@
 name="megasync-deb"
 gives="megasync"
 repology=("project: megasync")
-version="4.9.4"
-build_version="3.1"
+version="4.9.5"
+build_version="1.1"
 replace=("${gives}")
 breaks=("${gives}" "${gives}-bin" "${gives}-git" "${gives}-app" "${gives}-deb")
 incompatible=("debian:sid" "*:buster" "*:stretch" "*:jessie" "debian:testing" "*:bionic" "*:focal" "*:kinetic" "*:mantic")
@@ -21,7 +21,7 @@ case "${DISTRO#*:}" in
     ;;
   bookworm)
     distro_base="Debian"
-    distro_release="testing"
+    distro_release="12"
     hash="6fc4eda65d253bb42d4550e6a80fa0a6eda15978fe6dcebb61ff3e7a38c55096"
     ;;
   bullseye)

--- a/packages/megasync-deb/megasync-deb.pacscript
+++ b/packages/megasync-deb/megasync-deb.pacscript
@@ -19,6 +19,11 @@ case "${DISTRO#*:}" in
     distro_release="22.04"
     hash="69a0ef997f353ade109bfb74a58582e34d23574a23db69ee43a96685f4d2bdcf"
     ;;
+  trixie)
+    distro_base="Debian"
+    distro_release="testing"
+    hash="6a71b09fa3df1f4e1a98f1c89cb8ab4f5aa5e2a63a9e44f3baabaf089b98e483"
+    ;;
   bookworm)
     distro_base="Debian"
     distro_release="12"

--- a/packages/megasync-deb/megasync-deb.pacscript
+++ b/packages/megasync-deb/megasync-deb.pacscript
@@ -12,22 +12,22 @@ case "${DISTRO#*:}" in
   lunar)
     distro_base="xUbuntu"
     distro_release="23.04"
-    hash="e1c6d66b9946d0e5a427560a39c0b2affe72714b57b3a41ceefac8304a0a3113"
+    hash="f49c316c842e727deb222d84a829adde6a470581751eb101e920b11a3c368b1b"
     ;;
   jammy)
     distro_base="xUbuntu"
     distro_release="22.04"
-    hash="35a22daee1b9b5b8b2c619ebf80614a9781314cc1c5a3ad80d55af9d6cd6e378"
+    hash="69a0ef997f353ade109bfb74a58582e34d23574a23db69ee43a96685f4d2bdcf"
     ;;
   bookworm)
     distro_base="Debian"
     distro_release="12"
-    hash="6fc4eda65d253bb42d4550e6a80fa0a6eda15978fe6dcebb61ff3e7a38c55096"
+    hash="8f77fb8bffcf8ae68993b6d890a0dfd5ce23963c5e12b8e32cf69e1f6e2d0d9c"
     ;;
   bullseye)
     distro_base="Debian"
     distro_release="11"
-    hash="929189eeaed61ce33efba1a3ead6159cde9b9601147a68854345a1b9b955cda5"
+    hash="dab1ebe56184f91f209331189daddf46eac897b9d64bc70a7bf8d3dcbfbf2562"
     ;;
   *) ;;
 esac

--- a/packages/megasync-deb/megasync-deb.pacscript
+++ b/packages/megasync-deb/megasync-deb.pacscript
@@ -19,11 +19,6 @@ case "${DISTRO#*:}" in
     distro_release="22.04"
     hash="69a0ef997f353ade109bfb74a58582e34d23574a23db69ee43a96685f4d2bdcf"
     ;;
-  trixie)
-    distro_base="Debian"
-    distro_release="testing"
-    hash="6a71b09fa3df1f4e1a98f1c89cb8ab4f5aa5e2a63a9e44f3baabaf089b98e483"
-    ;;
   bookworm)
     distro_base="Debian"
     distro_release="12"


### PR DESCRIPTION
Only these distos are supported:

- Ubuntu 22.04
- Ubuntu 23.04
- Debian 11
- Debian 12