### PR TITLE
add: `mint-themes`

### DIFF
--- a/packagelist
+++ b/packagelist
@@ -233,6 +233,7 @@ microsoft-prod-repo
 minecraft-launcher
 minecraft-launcher-deb
 minecraft-pi-reborn-app
+mint-themes
 mobile-usb-networking-deb
 moka-icon-theme
 mold-bin

--- a/packages/mint-themes/mint-themes.pacscript
+++ b/packages/mint-themes/mint-themes.pacscript
@@ -15,8 +15,8 @@ optdepends=(
 )
 build() {
   cd "${srcdir}/${pkgname}"
-  sudo make clean
-  sudo make
+  make clean
+  make -j"${NCPU}"
 }
 package() {
   cd "${srcdir}/${pkgname}"

--- a/packages/mint-themes/mint-themes.pacscript
+++ b/packages/mint-themes/mint-themes.pacscript
@@ -1,0 +1,24 @@
+name="mint-themes"
+gives="mint-themes"
+version=2.1.5
+repology=("project: mint-themes")
+url="http://packages.linuxmint.com/pool/main/m/mint-themes/mint-themes_2.1.5.tar.xz"
+description="GTK 2, 3, and 4 themes from Linux Mint, for use with Cinammon, MATE, and Xfce."
+hash="685cff6598bdaf4b6813be3080368845f019e09e974e7f589b5f99acb3da2396"
+arch=(any)
+repology=("project: ${gives}")
+maintainer="badlydrawnface <bdface@proton.me>"
+build_depends=("python3" "sassc")
+optdepends=(
+    "mint-y-icons: Complementary icons for Mint-Y themes."
+    "mint-x-icons: Complementary icons for Mint-X themes."
+)
+build() {
+  cd "${srcdir}/${pkgname}"
+  sudo make clean
+  sudo make
+}
+package() {
+  cd "${srcdir}/${pkgname}"
+  sudo cp -r usr "${pkgdir}/"
+}

--- a/packages/mint-themes/mint-themes.pacscript
+++ b/packages/mint-themes/mint-themes.pacscript
@@ -8,8 +8,8 @@ repology=("project: ${gives}")
 maintainer="badlydrawnface <bdface@proton.me>"
 build_depends=("python3" "sassc")
 optdepends=(
-    "mint-y-icons: Complementary icons for Mint-Y themes."
-    "mint-x-icons: Complementary icons for Mint-X themes."
+  "mint-y-icons: Complementary icons for Mint-Y themes."
+  "mint-x-icons: Complementary icons for Mint-X themes."
 )
 
 build() {

--- a/packages/mint-themes/mint-themes.pacscript
+++ b/packages/mint-themes/mint-themes.pacscript
@@ -5,7 +5,6 @@ repology=("project: mint-themes")
 url="http://packages.linuxmint.com/pool/main/m/mint-themes/mint-themes_2.1.5.tar.xz"
 description="GTK 2, 3, and 4 themes from Linux Mint, for use with Cinammon, MATE, and Xfce."
 hash="685cff6598bdaf4b6813be3080368845f019e09e974e7f589b5f99acb3da2396"
-arch=(any)
 repology=("project: ${gives}")
 maintainer="badlydrawnface <bdface@proton.me>"
 build_depends=("python3" "sassc")

--- a/packages/mint-themes/mint-themes.pacscript
+++ b/packages/mint-themes/mint-themes.pacscript
@@ -1,7 +1,7 @@
 name="mint-themes"
 version=2.1.5
 repology=("project: mint-themes")
-url="http://packages.linuxmint.com/pool/main/m/mint-themes/mint-themes_2.1.5.tar.xz"
+url="http://packages.linuxmint.com/pool/main/m/mint-themes/mint-themes_${version}.tar.xz"
 description="GTK 2, 3, and 4 themes from Linux Mint, for use with Cinammon, MATE, and Xfce."
 hash="685cff6598bdaf4b6813be3080368845f019e09e974e7f589b5f99acb3da2396"
 repology=("project: ${gives}")

--- a/packages/mint-themes/mint-themes.pacscript
+++ b/packages/mint-themes/mint-themes.pacscript
@@ -11,6 +11,7 @@ optdepends=(
     "mint-y-icons: Complementary icons for Mint-Y themes."
     "mint-x-icons: Complementary icons for Mint-X themes."
 )
+
 build() {
   cd "${srcdir}/${pkgname}"
   make clean

--- a/packages/mint-themes/mint-themes.pacscript
+++ b/packages/mint-themes/mint-themes.pacscript
@@ -13,7 +13,6 @@ optdepends=(
 )
 
 build() {
-  cd "${srcdir}/${pkgname}"
   make clean
   make -j"${NCPU}"
 }

--- a/packages/mint-themes/mint-themes.pacscript
+++ b/packages/mint-themes/mint-themes.pacscript
@@ -18,6 +18,5 @@ build() {
 }
 
 package() {
-  cd "${srcdir}/${pkgname}"
   sudo cp -r usr "${pkgdir}/"
 }

--- a/packages/mint-themes/mint-themes.pacscript
+++ b/packages/mint-themes/mint-themes.pacscript
@@ -17,6 +17,7 @@ build() {
   make clean
   make -j"${NCPU}"
 }
+
 package() {
   cd "${srcdir}/${pkgname}"
   sudo cp -r usr "${pkgdir}/"

--- a/packages/mint-themes/mint-themes.pacscript
+++ b/packages/mint-themes/mint-themes.pacscript
@@ -1,5 +1,4 @@
 name="mint-themes"
-gives="mint-themes"
 version=2.1.5
 repology=("project: mint-themes")
 url="http://packages.linuxmint.com/pool/main/m/mint-themes/mint-themes_2.1.5.tar.xz"


### PR DESCRIPTION
Just because its hard to get as a package on Debian and Ubuntu when the Mint Y icons exist on both.