### PR TITLE
Revert "upd(cmake-data-deb): `3.25.1` -> `3.27.0` (#4149)"

### DIFF
--- a/packages/cmake-data-deb/cmake-data-deb.pacscript
+++ b/packages/cmake-data-deb/cmake-data-deb.pacscript
@@ -1,16 +1,16 @@
 name="cmake-data-deb"
 gives="cmake-data"
-version="3.27.0"
+version="3.25.1"
 description="CMake data files (modules, templates and documentation)"
 codename="$(lsb_release -cs)"
 case "${codename}" in
   "bullseye")
-    url="http://ftp.debian.org/debian/pool/main/c/cmake/cmake-data_${version}-2_all.deb"
-    hash="5f94ce4ed55111d56a3f387e81edc713099b5084a15dfb7d9c620e38bf207e96"
+    url="http://ftp.debian.org/debian/pool/main/c/cmake/cmake-data_${version}-1~bpo11+1_all.deb"
+    hash="6c7c8d91c045ccf44c9cc7dc1f05d8431707df4651bf18b4a3ee34847bc205f3"
     ;;
   *)
-    url="http://archive.ubuntu.com/ubuntu/pool/main/c/cmake/cmake-data_${version}-2_all.deb"
-    hash="17936d368614bd835ad2a79c87e25e06199109c87a5e4351749899c8aff8ddd8"
+    url="http://archive.ubuntu.com/ubuntu/pool/main/c/cmake/cmake-data_${version}-1ubuntu1_all.deb"
+    hash="8633c1235e841faa70eb1c58f451338a73048dbddb4d97c482cca92dde61c567"
     ;;
 esac
 arch=('amd64')


### PR DESCRIPTION
This reverts commit acae0cfb8970aab48c5ae6fbfc0867983a7e78f7.

The update I did to cmake-data-deb was to update cmake-deb but cmake-deb 3.27.0 will not install on ubuntu jammy, kinetic, and lunar so I would like to revert that commit to unbreak cmake-deb until I find a better solution

Sorry about that