### PR TITLE
add: `xone-git`

### DIFF
--- a/packagelist
+++ b/packagelist
@@ -441,6 +441,7 @@ xapps-common-deb
 xfce4-deb
 xfce4-settings-pine-git
 xmind-vana-deb
+xone-git
 yabridge
 yad
 yafetch-git

--- a/packages/xone-git/xone-git.pacscript
+++ b/packages/xone-git/xone-git.pacscript
@@ -6,43 +6,23 @@ provides=('xone')
 homepage='https://github.com/medusalix/xone#readme'
 url="https://github.com/medusalix/xone.git"
 arch=('amd64')
-makedepends=('git' 'curl' 'cabextract')
+makedepends=('cabextract')
 depends=('dkms' 'linux-headers-generic')
 maintainer="FelisDiligens <47528453+FelisDiligens@users.noreply.github.com>"
-
 pkgver() {
   git ls-remote "${url}" master | cut -f1 | cut -c1-8
 }
 
-prepare() {
-  if lsmod | grep -q '^xone_'; then
-    echo '* xone already installed... uninstall it before updating! (Run: pacstall -R xone-git)' >&2
-    exit 1
-  fi
-
-  if [[ -f "/usr/local/bin/xow" ]]; then
-    echo '* Please uninstall xow!' >&2
-    exit 1
-  fi
-}
-
 package() {
-  echo "* Preparing module..."
   # We can't use "git describe" because the repo is cloned shallowly by pacstall...
   # version=$(git describe --tags 2> /dev/null || echo unknown) # "v0.3-2-gbbf0dcc"
   version="v${pkgver}-$(git rev-parse HEAD | cut -c1-8)" # "v0.3-bbf0dcc4", close enough...
   find . -type f \( -name 'dkms.conf' -o -name '*.c' \) -exec sed -i "s/#VERSION#/${version}/" {} +
 
-  echo "* Copying module into /usr/src..."
   sudo install -dm755 "${pkgdir}/usr/src/xone-${version}"
   sudo cp -r ./* "${pkgdir}/usr/src/xone-${version}"
 
-  echo "* Blacklisting xpad module..."
   sudo install -D -m 644 install/modprobe.conf "${pkgdir}/etc/modprobe.d/xone-blacklist.conf"
-
-  echo "* Extracting dongle firmware..."
-  echo "* The firmware for the wireless dongle is subject to Microsoft's Terms of Use:"
-  echo "* https://www.microsoft.com/en-us/legal/terms-of-use"
 
   driver_url='http://download.windowsupdate.com/c/msdownload/update/driver/drvs/2017/07/1cd6a87c-623f-4407-a52d-c31be49e925c_e19f60808bdcbfbd3c3df6be3e71ffc52e43261e.cab'
   firmware_hash='48084d9fa53b9bb04358f3bb127b7495dc8f7bb0b3ca1437bd24ef2b6eabdf66'
@@ -52,19 +32,15 @@ package() {
   if echo "${firmware_hash}" FW_ACC_00U.bin | sha256sum -c; then
     sudo install -D -m 644 "${srcdir}/FW_ACC_00U.bin" "${pkgdir}/usr/lib/firmware/xow_dongle.bin"
   else
-    echo "* Checksum did not match!"
-    exit 1
+    return 1
   fi
 }
 
 post_install() {
-  echo "* Getting xone version"
   version="$(find /usr/src -maxdepth 1 -type d -name "xone-*" | head -n 1 | sed 's|/usr/src/xone-||')"
 
-  echo "* Running 'dkms install'"
   sudo dkms install -m xone -v "${version}"
 
-  echo "* Unloading conflicting kernel modules"
   # Avoid conflicts between xpad and xone
   if lsmod | grep -q '^xpad'; then
     sudo modprobe -r xpad
@@ -80,14 +56,12 @@ post_remove() {
   modules=$(lsmod | grep '^xone_' | cut -d ' ' -f 1 | tr '\n' ' ')
 
   if [[ -n ${modules} ]]; then
-    echo "* Unloading modules: ${modules}"
     read -ra modules_array <<< "${modules}"
     sudo modprobe -r -a "${modules_array[@]}" # SC2086
   fi
 
   # There is no pre_remove() function, so we cannot run "dkms remove" before removing "dkms.conf".
   # Therefore we have to delete the modules manually:
-  echo "* Deleting xone dkms files"
   sudo rm -rfv /var/lib/dkms/xone
   sudo rm -rfv /lib/modules/**/updates/dkms/xone-*.ko
 }

--- a/packages/xone-git/xone-git.pacscript
+++ b/packages/xone-git/xone-git.pacscript
@@ -1,0 +1,93 @@
+name="xone-git"
+pkgname="xone"
+pkgdesc="Linux kernel driver for Xbox One and Xbox Series X|S accessories"
+pkgver="0.3"
+provides=('xone')
+homepage='https://github.com/medusalix/xone#readme'
+url="https://github.com/medusalix/xone.git"
+arch=('amd64')
+makedepends=('git' 'curl' 'cabextract')
+depends=('dkms' 'linux-headers-generic')
+maintainer="FelisDiligens <47528453+FelisDiligens@users.noreply.github.com>"
+
+pkgver() {
+  git ls-remote "${url}" master | cut -f1 | cut -c1-8
+}
+
+prepare() {
+  if lsmod | grep -q '^xone_'; then
+    echo '* xone already installed... uninstall it before updating! (Run: pacstall -R xone-git)' >&2
+    exit 1
+  fi
+
+  if [[ -f "/usr/local/bin/xow" ]]; then
+    echo '* Please uninstall xow!' >&2
+    exit 1
+  fi
+}
+
+package() {
+  echo "* Preparing module..."
+  # We can't use "git describe" because the repo is cloned shallowly by pacstall...
+  # version=$(git describe --tags 2> /dev/null || echo unknown) # "v0.3-2-gbbf0dcc"
+  version="v${pkgver}-$(git rev-parse HEAD | cut -c1-8)" # "v0.3-bbf0dcc4", close enough...
+  find . -type f \( -name 'dkms.conf' -o -name '*.c' \) -exec sed -i "s/#VERSION#/${version}/" {} +
+
+  echo "* Copying module into /usr/src..."
+  sudo install -dm755 "${pkgdir}/usr/src/xone-${version}"
+  sudo cp -r ./* "${pkgdir}/usr/src/xone-${version}"
+
+  echo "* Blacklisting xpad module..."
+  sudo install -D -m 644 install/modprobe.conf "${pkgdir}/etc/modprobe.d/xone-blacklist.conf"
+
+  echo "* Extracting dongle firmware..."
+  echo "* The firmware for the wireless dongle is subject to Microsoft's Terms of Use:"
+  echo "* https://www.microsoft.com/en-us/legal/terms-of-use"
+
+  driver_url='http://download.windowsupdate.com/c/msdownload/update/driver/drvs/2017/07/1cd6a87c-623f-4407-a52d-c31be49e925c_e19f60808bdcbfbd3c3df6be3e71ffc52e43261e.cab'
+  firmware_hash='48084d9fa53b9bb04358f3bb127b7495dc8f7bb0b3ca1437bd24ef2b6eabdf66'
+
+  curl -L -o driver.cab "${driver_url}"
+  cabextract -F FW_ACC_00U.bin driver.cab
+  if echo "${firmware_hash}" FW_ACC_00U.bin | sha256sum -c; then
+    sudo install -D -m 644 "${srcdir}/FW_ACC_00U.bin" "${pkgdir}/usr/lib/firmware/xow_dongle.bin"
+  else
+    echo "* Checksum did not match!"
+    exit 1
+  fi
+}
+
+post_install() {
+  echo "* Getting xone version"
+  version="$(find /usr/src -maxdepth 1 -type d -name "xone-*" | head -n 1 | sed 's|/usr/src/xone-||')"
+
+  echo "* Running 'dkms install'"
+  sudo dkms install -m xone -v "${version}"
+
+  echo "* Unloading conflicting kernel modules"
+  # Avoid conflicts between xpad and xone
+  if lsmod | grep -q '^xpad'; then
+    sudo modprobe -r xpad
+  fi
+
+  # Avoid conflicts between mt76x2u and xone
+  if lsmod | grep -q '^mt76x2u'; then
+    sudo modprobe -r mt76x2u
+  fi
+}
+
+post_remove() {
+  modules=$(lsmod | grep '^xone_' | cut -d ' ' -f 1 | tr '\n' ' ')
+
+  if [[ -n ${modules} ]]; then
+    echo "* Unloading modules: ${modules}"
+    read -ra modules_array <<< "${modules}"
+    sudo modprobe -r -a "${modules_array[@]}" # SC2086
+  fi
+
+  # There is no pre_remove() function, so we cannot run "dkms remove" before removing "dkms.conf".
+  # Therefore we have to delete the modules manually:
+  echo "* Deleting xone dkms files"
+  sudo rm -rfv /var/lib/dkms/xone
+  sudo rm -rfv /lib/modules/**/updates/dkms/xone-*.ko
+}

--- a/packages/xone-git/xone-git.pacscript
+++ b/packages/xone-git/xone-git.pacscript
@@ -8,6 +8,7 @@ url="https://github.com/medusalix/xone.git"
 arch=('amd64')
 makedepends=('cabextract')
 depends=('dkms' 'linux-headers-generic')
+optdepends=("linux-headers-$(uname -r): Linux kernel headers for the currently installed version")
 maintainer="FelisDiligens <47528453+FelisDiligens@users.noreply.github.com>"
 pkgver() {
   git ls-remote "${url}" master | cut -f1 | cut -c1-8


### PR DESCRIPTION
## Progress 

- [x] Edit packagelist
- [x] Add initial pacscript
- [ ] Contact devs
- [ ] Add maintainer to pacscript

## Description

[xone](https://github.com/medusalix/xone) is a Linux kernel driver (dkms) for Xbox One and Xbox Series X|S accessories. It makes it possible to use the official [Xbox wireless adapter](https://www.xbox.com/en-US/accessories/adapters/wireless-adapter-windows).

I tried to mostly replicate the behavior of the installation/uninstallation scripts from the original project, see:
- [xone/install.sh](https://github.com/medusalix/xone/blob/master/install.sh)
- [xone/uninstall.sh](https://github.com/medusalix/xone/blob/master/uninstall.sh)
- [xone/install/firmware.sh](https://github.com/medusalix/xone/blob/master/install/firmware.sh)

See also:
- [AUR: xone-dkms-git](https://aur.archlinux.org/packages/xone-dkms-git)
- [AUR: xone-dongle-firmware](https://aur.archlinux.org/packages/xone-dongle-firmware)

I tested it locally on my Ubuntu 23.04 installation. (`pacstall -I` and `-R`)

First commit here, I hope I'm doing this right. ^^