### PR TITLE
fix(rhino-pine-core): modem-start deprecated

### DIFF
--- a/packages/rhino-pine-core/rhino-pine-core.pacscript
+++ b/packages/rhino-pine-core/rhino-pine-core.pacscript
@@ -1,7 +1,7 @@
 name="rhino-pine-core"
 url="https://github.com/oklopfer/debs/raw/master/empty.tar.xz"
 pacdeps=("unicorn-mobile-git" "rhino-kvantum-theme-git" "rhino-plymouth-theme-git" "rhino-pkg-git" "rhino-neofetch-git" "rhino-system-git" "u-boot-mobian-deb" "mobile-usb-networking-deb")
-if [[ -f /usr/lib/systemd/system/modem-start.service ]]; then
+if [[ -f /usr/bin/enable-modem ]]; then
   depends=("eg25-manager" "modemmanager" "gnome-calls" "gnome-contacts" "chatty" "callaudiod" "feedbackd" "purple-mm-sms" "ofono" "ofono-scripts")
 fi
 pkgdesc="Transitional package to provide all core Rhino Linux Mobile software"
@@ -24,7 +24,4 @@ SUPPORT_URL=\"https://github.com/rhino-linux\"
 BUG_REPORT_URL=\"https://github.com/rhino-linux\"
 PRIVACY_POLICY_URL=\"https://www.ubuntu.com/legal/terms-and-policies/privacy-policy\"
 UBUNTU_CODENAME=\"${branch}\"" | sudo tee /usr/lib/os-release > /dev/null
-  if [[ -f /usr/lib/systemd/system/modem-start.service ]]; then
-    sudo systemctl enable modem-start.service
-  fi
 }


### PR DESCRIPTION
This does NOT need a pkgrel bump as it will not have an effect on any current users whatsoever. This is purely for the pipeline creating 2023.2+