### PR TITLE
upd(megasync-deb): `4.9.5-1.1` -> `4.9.6-1.1`

### DIFF
--- a/packages/megasync-deb/megasync-deb.pacscript
+++ b/packages/megasync-deb/megasync-deb.pacscript
@@ -1,7 +1,7 @@
 name="megasync-deb"
 gives="megasync"
 repology=("project: megasync")
-pkgver="4.9.5"
+pkgver="4.9.6"
 build_version="1.1"
 replace=("${gives}")
 breaks=("${gives}" "${gives}-bin" "${gives}-git" "${gives}-app" "${gives}-deb")
@@ -12,22 +12,22 @@ case "${DISTRO#*:}" in
   lunar)
     distro_base="xUbuntu"
     distro_release="23.04"
-    hash="f49c316c842e727deb222d84a829adde6a470581751eb101e920b11a3c368b1b"
+    hash="5f37dacf8da5ca3efaca50fb462553d361ef34a75a553c5fcd2202f2e624b56a"
     ;;
   jammy)
     distro_base="xUbuntu"
     distro_release="22.04"
-    hash="69a0ef997f353ade109bfb74a58582e34d23574a23db69ee43a96685f4d2bdcf"
+    hash="9c7980b6f7551786daff03738528bdc70b7df5c2193953c80140af50f63b4121"
     ;;
   bookworm)
     distro_base="Debian"
     distro_release="12"
-    hash="8f77fb8bffcf8ae68993b6d890a0dfd5ce23963c5e12b8e32cf69e1f6e2d0d9c"
+    hash="083bb006cc71038e04fb90b97f6b837f0539c7f8c2f4eaa4c38890ef12c134ac"
     ;;
   bullseye)
     distro_base="Debian"
     distro_release="11"
-    hash="dab1ebe56184f91f209331189daddf46eac897b9d64bc70a7bf8d3dcbfbf2562"
+    hash="38a30c5743f250975502bde45b3fd87ffaae031ca76aa6fd69d6605cf363662c"
     ;;
   *) ;;
 esac


### PR DESCRIPTION
Only compatible with:

    Ubuntu 22.04 and derivatives
    Ubuntu 23.04 and derivatives
    Debian 11
    Debian 12

