### PR TITLE
fix(lutris-deb): add `depends`

### DIFF
--- a/packages/lutris-deb/lutris-deb.pacscript
+++ b/packages/lutris-deb/lutris-deb.pacscript
@@ -3,6 +3,7 @@ pkgver="0.5.13"
 gives="lutris"
 repology=("project: lutris")
 url="https://github.com/lutris/lutris/releases/download/v${pkgver}/lutris_${pkgver}_all.deb"
+depends=("python3-gi-cairo")
 pkgdesc="open source gaming platform"
 hash="03b30cf80f048b5a71c80b63ba2b7145676cca4ed39a0d0f90b90bed865b3236"
 maintainer="Oren Klopfer <oren@taumoda.com>"

--- a/packages/lutris-deb/lutris-deb.pacscript
+++ b/packages/lutris-deb/lutris-deb.pacscript
@@ -7,4 +7,3 @@ depends=("python3-gi-cairo")
 pkgdesc="open source gaming platform"
 hash="03b30cf80f048b5a71c80b63ba2b7145676cca4ed39a0d0f90b90bed865b3236"
 maintainer="Oren Klopfer <oren@taumoda.com>"
-

--- a/packages/lutris-deb/lutris-deb.pacscript
+++ b/packages/lutris-deb/lutris-deb.pacscript
@@ -7,3 +7,4 @@ depends=("python3-gi-cairo")
 pkgdesc="open source gaming platform"
 hash="03b30cf80f048b5a71c80b63ba2b7145676cca4ed39a0d0f90b90bed865b3236"
 maintainer="Oren Klopfer <oren@taumoda.com>"
+


### PR DESCRIPTION
Missing dependency from github .deb (useless if using OBS repository, bug reported to lutris team too)

Permit the header banner to be visible on lutris