### PR TITLE
upd(rhino-pkg-git): `0.1.1` -> `0.1.2`

### DIFF
--- a/packages/rhino-pkg-git/rhino-pkg-git.pacscript
+++ b/packages/rhino-pkg-git/rhino-pkg-git.pacscript
@@ -1,6 +1,6 @@
 name="rhino-pkg-git"
 url="https://github.com/rhino-linux/rhino-pkg.git"
-pkgver="0.1.1"
+pkgver="0.1.2"
 gives="rhino-pkg"
 makedepends=("make" "gettext")
 depends=("gettext")


### PR DESCRIPTION
Update rhino-pkg-git to v0.1.2 when https://github.com/rhino-linux/rhino-pkg/issues/32 is closed.