### PR TITLE
upd(discord-canary): `0.0.170` -> `0.0.171`

### DIFF
--- a/packages/discord-canary/discord-canary.pacscript
+++ b/packages/discord-canary/discord-canary.pacscript
@@ -1,13 +1,13 @@
 name="discord-canary"
-repology=("project: discord-canary" "repo: aur")
-pkgver="0.0.170"
+repology=("project: discord-canary")
+pkgver="0.0.171"
 maintainer="DismissedGuy <me@mikealmel.ooo>"
 url="https://dl-canary.discordapp.net/apps/linux/${pkgver}/${name}-${pkgver}.tar.gz"
 homepage='https://discord.com/'
 depends=("libc6" "libasound2" "libatomic1" "libnotify4" "libnspr4" "libnss3" "libstdc++6" "libxss1" "libxtst6" "libc++1" "libatk1.0-0" "libatk-bridge2.0-0" "libcups2" "libdrm2" "libgtk-3-0" "libgbm1")
 pkgdesc="Chat for Communities and Friends - Unstable"
 arch=('amd64')
-hash="2f0faa2c0030ca80c12833ce040f4747bf60727ab04ec845aba18ca454b4b570"
+hash="35c995f833c8e617cd741520a1a38bb231b7d907e317ec7b7f4d41e8f475d157"
 
 prepare() {
   sudo mkdir -p "${pkgdir}/usr/share/${name}/"


### PR DESCRIPTION
Also removes repology AUR pinning since that issue appears to be fixed now.