### PR TITLE
upd(wezterm-app): `20230408-112425-69ae8472` -> `20230712-072601-f4abf8fd` Update Package 

### DIFF
--- a/packages/wezterm-app/wezterm-app.pacscript
+++ b/packages/wezterm-app/wezterm-app.pacscript
@@ -1,10 +1,10 @@
 name="wezterm-app"
 pkgname="wezterm"
 gives="wezterm"
-pkgver="20230408-112425-69ae8472"
+pkgver="20230712-072601-f4abf8fd"
 pkgdesc="A GPU-accelerated cross-platform terminal emulator and multiplexer written by @wez and implemented in Rust"
 url="https://github.com/wez/wezterm/releases/download/${pkgver}/WezTerm-${pkgver}-Ubuntu20.04.AppImage"
-hash="24281a5369fb56144b4dcaafcaa1df621c2941b1a2d2e5576d76454d287cfd07"
+hash="68656714c332161c47862f74902d676088ba45ca3980d6d2cbc2c3d9dd4a9c72"
 breaks=("${pkgname}-bin")
 repology=("project: wezterm")
 maintainer="smokeythemonkey <smokeythemonkey@posteo.net>"
@@ -14,8 +14,8 @@ package() {
   sudo install -Dm755 "WezTerm-${pkgver}-Ubuntu20.04.AppImage" "${pkgdir}/usr/bin/${pkgname}"
 
   # Download icon
-  wget -q https://github.com/wez/wezterm/blob/main/assets/icon/terminal.png
-  sudo install -Dm644 "terminal.png" "${pkgdir}/usr/share/icons/hicolor/128x128/apps/org.wezfurlong.wezterm.png"
+  wget -q https://raw.githubusercontent.com/wez/wezterm/main/assets/icon/wezterm-icon.svg
+  sudo install -Dm644 "wezterm-icon.svg" "${pkgdir}/usr/share/icons/hicolor/128x128/apps/org.wezfurlong.wezterm.svg"
 
   # Install .desktop file
   wget -q "https://raw.githubusercontent.com/pacstall/pacstall-programs/master/packages/${name}/${pkgname}.desktop"
@@ -24,7 +24,7 @@ package() {
 
 post_remove() {
   # Delete wezterm config
-  if ask "Do you want to delete ~/.wezterm/ files?" N; then
-    rm -rf ~/.config/.wezterm/
+  if ask "Do you want to delete ~/.config/wezterm/ files?" N; then
+    rm -rf ~/.config/wezterm/
   fi
 }


### PR DESCRIPTION
Updated Package
Fixed removal of default config to actually point to config 
Fixed method for fetching the icon as it was giving me weird resutls - was downloading an unopenable file.

One thing - why is there a .desktop file included in the `wezterm-app` dir - there is a line that then downloads and installs one - maybe im missing something.