### PR TITLE
fix(pacstall-gui-git): change pacdepends="yad" to depends="yad"

### DIFF
--- a/packages/pacstall-gui-git/pacstall-gui-git.pacscript
+++ b/packages/pacstall-gui-git/pacstall-gui-git.pacscript
@@ -1,6 +1,6 @@
 name="pacstall-gui-git"
-pacdeps=("yad")
-depends=("sed" "adwaita-icon-theme" "policykit-1" "desktop-file-utils")
+#pacdeps=("yad")
+depends=("yad" "sed" "adwaita-icon-theme" "policykit-1" "desktop-file-utils")
 url="https://github.com/cat-master21/pacstall-gui.git"
 pkgver="0.0.1"
 gives="pacstall-gui"

--- a/packages/pacstall-gui-git/pacstall-gui-git.pacscript
+++ b/packages/pacstall-gui-git/pacstall-gui-git.pacscript
@@ -1,5 +1,4 @@
 name="pacstall-gui-git"
-#pacdeps=("yad")
 depends=("yad" "sed" "adwaita-icon-theme" "policykit-1" "desktop-file-utils")
 url="https://github.com/cat-master21/pacstall-gui.git"
 pkgver="0.0.1"


### PR DESCRIPTION
yad is available on Ubuntu and Debian. Compiling from source breaks the native one with bad version (yad 13 / yad 0.40)

Tested OK 30/10/2023 Debian 12/Ubuntu 22.04