### PR TITLE
fix(yad): change yad to yad-git

### DIFF
--- a/packages/yad/yad-git.pacscript
+++ b/packages/yad/yad-git.pacscript
@@ -1,4 +1,4 @@
-name="yad"
+name="yad-git"
 pkgver="13.0"
 url="https://github.com/v1cont/${name}/releases/download/v${pkgver}/${name}-${pkgver}.tar.xz"
 makedepends=("autotools-dev" "intltool" "libgtk-3-dev" "automake")

--- a/packages/yad/yad-git.pacscript
+++ b/packages/yad/yad-git.pacscript
@@ -1,9 +1,10 @@
 name="yad-git"
+prettyname="yad"
 pkgver="13.0"
-url="https://github.com/v1cont/${name}/releases/download/v${pkgver}/${name}-${pkgver}.tar.xz"
+url="https://github.com/v1cont/${prettyname}/releases/download/v${pkgver}/${prettyname}-${pkgver}.tar.xz"
 makedepends=("autotools-dev" "intltool" "libgtk-3-dev" "automake")
 depends=("libc6" "libcairo2" "libgdk-pixbuf2.0-0" "libglib2.0-0" "libgtk-3-0" "libpango-1.0-0" "libpangocairo-1.0-0")
-breaks="${name} ${name}-bin ${name}-app ${name}-git ${name}-deb"
+breaks="${prettyname} ${prettyname}-bin ${prettyname}-app ${prettyname}-git ${prettyname}-deb"
 gives="yad"
 pkgdesc="Yet Another Dialog"
 hash="194198c4a58e20ceffd9a3206633c3726d962d7d4219edb77aeb748897403e34"


### PR DESCRIPTION
Too many regressions/differences in yad github comparing to official yad 0.40 provided by debian/ubuntu

Packages must be differentiated to avoid problems.