### PR TITLE
upd(zettlr-deb): `2.3.0` -> `3.0.2`

### DIFF
--- a/packages/zettlr-deb/zettlr-deb.pacscript
+++ b/packages/zettlr-deb/zettlr-deb.pacscript
@@ -1,10 +1,10 @@
 name="zettlr-deb"
 pkgname="zettlr"
 gives="zettlr"
-pkgver="2.3.0"
+pkgver="3.0.2"
 pkgdesc="Markdown editor for the 21st century"
 url="https://github.com/Zettlr/Zettlr/releases/download/v${pkgver}/Zettlr-${pkgver}-amd64.deb"
-hash="3c31c080e42133075d4b1b6e4c436467e37ae4682d8864ca6798c1b402ca2e72"
+hash="8a5c991eace2d1c13225591341bd74e958e9ffb209c1ae18f459b12d2a850015"
 repology=("project: zettlr")
 arch=('amd64')
 maintainer="smokeythemonkey <smokeythemonkey@posteo.net>"


### PR DESCRIPTION
Closes #4749.