### PR TITLE
fix(meson-focal-deb): use `compatible` array

### DIFF
--- a/packages/meson-focal-deb/meson-focal-deb.pacscript
+++ b/packages/meson-focal-deb/meson-focal-deb.pacscript
@@ -1,9 +1,10 @@
 name="meson-focal-deb"
 pkgver="0.61.2"
+pkgrel="2"
 gives="meson"
 url="https://github.com/oklopfer/debs/raw/master/meson-focal/${gives}_${pkgver}-1_all.deb"
 hash="d9c97eac0a3573a98db98a7e56e043968da8ad7908c31f6b16daa19febd28e9b"
 maintainer="Oren Klopfer <oren@taumoda.com>"
 pkgdesc="Special built meson for compiling on focal"
 arch=('any')
-incompatible=("ubuntu:20.10" "ubuntu:21.04" "ubuntu:21.10" "ubuntu:22.04" "ubuntu:22.10" "ubuntu:23.04" "ubuntu:23.10" "ubuntu:devel" "debian:*")
+compatible=("ubuntu:focal")


### PR DESCRIPTION
mfw the array was made with this package hyper-specifically in mind but I never updated it 