### PR TITLE
add: `watchexec`

### DIFF
--- a/packagelist
+++ b/packagelist
@@ -461,6 +461,7 @@ waf
 walc-app
 warp
 warpinator-deb
+watchexec
 webapp-manager
 webapp-manager-deb
 webcord-deb

--- a/packages/watchexec/watchexec.pacscript
+++ b/packages/watchexec/watchexec.pacscript
@@ -1,0 +1,21 @@
+name="watchexec"
+pkgdesc="Executes commands in response to file modifications"
+maintainer="Andrew Barchuk <andrew@raindev.io>"
+pkgver="1.24.2"
+arch=('amd64' 'arm64')
+if [[ ${CARCH} == amd64 ]]; then
+    hash="928d642408c62ad9d955939a5af62b07b7c5210d1c0bf3c974354ec41dc4e3fd"
+    arch_prefix="x86_64"
+else
+    hash="67e2d7626231d1123ace6cb386af816d132858746dbd465aef1fca210b88785c"
+    arch_prefix="aarch64"
+fi
+url="https://github.com/watchexec/watchexec/releases/download/v${pkgver}/watchexec-${pkgver}-${arch_prefix}-unknown-linux-gnu.tar.xz"
+
+package() {
+  sudo install -Dm755 "./watchexec" -t "${pkgdir}/usr/bin"
+  sudo install -Dm644 "./watchexec.1" -t "${pkgdir}/usr/share/man/man1"
+  sudo install -Dm644 "./completions/bash" "${pkgdir}/usr/share/bash-completion/completions/${name}"
+}
+
+# vim:set ft=sh ts=2 sw=2 et:

--- a/packages/watchexec/watchexec.pacscript
+++ b/packages/watchexec/watchexec.pacscript
@@ -11,7 +11,7 @@ else
 fi
 url="https://github.com/watchexec/watchexec/releases/download/v${pkgver}/watchexec-${pkgver}-${arch_prefix}-unknown-linux-gnu.tar.xz"
 pkgdesc="Executes commands in response to file modifications"
-homepage="https://watchexec.github.io/"
+homepage='https://watchexec.github.io/'
 maintainer="Andrew Barchuk <andrew@raindev.io>"
 
 package() {

--- a/packages/watchexec/watchexec.pacscript
+++ b/packages/watchexec/watchexec.pacscript
@@ -1,6 +1,5 @@
 name="watchexec"
-pkgdesc="Executes commands in response to file modifications"
-maintainer="Andrew Barchuk <andrew@raindev.io>"
+repology=("project: watchexec")
 pkgver="1.24.2"
 arch=('amd64' 'arm64')
 if [[ ${CARCH} == amd64 ]]; then
@@ -11,6 +10,9 @@ else
     arch_prefix="aarch64"
 fi
 url="https://github.com/watchexec/watchexec/releases/download/v${pkgver}/watchexec-${pkgver}-${arch_prefix}-unknown-linux-gnu.tar.xz"
+pkgdesc="Executes commands in response to file modifications"
+homepage="https://watchexec.github.io/"
+maintainer="Andrew Barchuk <andrew@raindev.io>"
 
 package() {
   sudo install -Dm755 "./watchexec" -t "${pkgdir}/usr/bin"


### PR DESCRIPTION
Add an initial version of watchexec package. The project supports more architectures and provides completion for more shells, I only added the ones I use and can easily test.