### PR TITLE
fix(plexmediaserver-deb): fix deb URL for arm64

### DIFF
--- a/packages/plexmediaserver-deb/plexmediaserver-deb.pacscript
+++ b/packages/plexmediaserver-deb/plexmediaserver-deb.pacscript
@@ -3,7 +3,7 @@ gives="plexmediaserver"
 repology=("project: ${gives}")
 pkgver="1.32.0.6918-6f393eda1"
 replace=("${gives}")
-url="https://downloads.plex.tv/plex-media-server-new/${pkgver}/debian/${gives}_${pkgver}_amd64.deb"
+url="https://downloads.plex.tv/plex-media-server-new/${pkgver}/debian/${gives}_${pkgver}_${CARCH}.deb"
 pkgdesc="Plex organizes all of your personal media so you can easily access and enjoy it"
 case "${CARCH}" in
   amd64)


### PR DESCRIPTION
Parameterize the download URL based on architecture
