### PR TITLE
fix(rhino*core): `2023.4-1` -> `2023.4-2`

### DIFF
--- a/packages/rhino-core/rhino-core.pacscript
+++ b/packages/rhino-core/rhino-core.pacscript
@@ -7,7 +7,7 @@ compatible=("ubuntu:devel" "ubuntu:noble")
 replace=("rhino-pine-core" "rhino-server-core" "rhino-ubxi-core")
 priority="essential"
 pkgver="2023.4"
-pkgrel="1"
+pkgrel="2"
 style="(mainline)"
 branch="devel"
 post_install() {

--- a/packages/rhino-pine-core/rhino-pine-core.pacscript
+++ b/packages/rhino-pine-core/rhino-pine-core.pacscript
@@ -11,7 +11,7 @@ compatible=("ubuntu:devel" "ubuntu:noble")
 replace=("rhino-core" "rhino-server-core" "rhino-ubxi-core")
 priority="essential"
 pkgver="2023.4"
-pkgrel="1"
+pkgrel="2"
 style="(mobile)"
 branch="devel"
 post_install() {

--- a/packages/rhino-server-core/rhino-server-core.pacscript
+++ b/packages/rhino-server-core/rhino-server-core.pacscript
@@ -7,7 +7,7 @@ compatible=("ubuntu:devel" "ubuntu:noble")
 replace=("rhino-core" "rhino-pine-core" "rhino-ubxi-core")
 priority="essential"
 pkgver="2023.4"
-pkgrel="1"
+pkgrel="2"
 style="(server)"
 branch="devel"
 post_install() {

--- a/packages/rhino-ubxi-core/rhino-ubxi-core.pacscript
+++ b/packages/rhino-ubxi-core/rhino-ubxi-core.pacscript
@@ -7,7 +7,7 @@ compatible=("ubuntu:devel" "ubuntu:noble")
 replace=("rhino-core" "rhino-pine-core" "rhino-server-core")
 priority="essential"
 pkgver="2023.4"
-pkgrel="1"
+pkgrel="2"
 style="(ubxi)"
 branch="devel"
 post_install() {


### PR DESCRIPTION
- bump: rhino-*-core pkgrel since Ubuntu updated /etc/os-release.
