### PR TITLE
upd(discord): `0.0.36` -> `0.0.39`

### DIFF
--- a/packages/discord/discord.pacscript
+++ b/packages/discord/discord.pacscript
@@ -1,11 +1,11 @@
 name="discord"
-pkgver="0.0.36"
+pkgver="0.0.39"
 maintainer="Elsie19 <elsie19@pm.me>"
 url="https://dl.discordapp.net/apps/linux/${pkgver}/${name}-${pkgver}.tar.gz"
 homepage='https://discord.com/'
 depends=("libc6" "libasound2" "libatomic1" "libnotify4" "libnspr4" "libnss3" "libstdc++6" "libxss1" "libxtst6" "libayatana-appindicator3-1" "libc++1")
 pkgdesc="Chat for Communities and Friends"
-hash="9e99a9f3d285f7297f1f5d748ce3a8594f45528c1a8bdaaeea4967074601c1c2"
+hash="2992ca07377d85d390929ee6374ad467c4db32f1f61b4fc07f01cf2c0943a6e8"
 arch=('amd64')
 repology=("project: ${name}")
 


### PR DESCRIPTION
Updating Discord Version from 0.0.36 to 0.0.39

TESTED: Ubuntu 22.04