### PR TITLE
fix(stockfish-git): improve build sequence

### DIFF
--- a/packages/stockfish-git/stockfish-git.pacscript
+++ b/packages/stockfish-git/stockfish-git.pacscript
@@ -13,7 +13,6 @@ pkgver() {
 build(){
   cd src
   make -j"${NCPU}" profile-build
-
 }
 
 package() {

--- a/packages/stockfish-git/stockfish-git.pacscript
+++ b/packages/stockfish-git/stockfish-git.pacscript
@@ -13,7 +13,7 @@ pkgver() {
 build(){
   cd src
   make -j"${NCPU}" profile-build
-  
+
 }
 
 package() {

--- a/packages/stockfish-git/stockfish-git.pacscript
+++ b/packages/stockfish-git/stockfish-git.pacscript
@@ -12,10 +12,12 @@ pkgver() {
 
 build(){
   cd src
-  make -j"${NCPU}" build
+  make -j"${NCPU}" profile-build
+  
 }
 
 package() {
   cd src
+  make strip
   sudo make install BINDIR="${pkgdir}/usr/local/bin"
 }


### PR DESCRIPTION
I missed the key step of stripping the exectuable to make it smaller and faster, as well as using profile-build to do something good. This has been tested on my jetson xavier and jetson nano, so it will probably work. Thank y'all!