### PR TITLE
upd(megasync-deb): `4.9.6-1.1` -> `4.11.0-3.1`

### DIFF
--- a/packages/megasync-deb/megasync-deb.pacscript
+++ b/packages/megasync-deb/megasync-deb.pacscript
@@ -27,12 +27,12 @@ case "${DISTRO#*:}" in
   bookworm)
     distro_base="Debian"
     distro_release="12"
-    hash="03a9fe62162e69df95c4a4394319110964de2cf019db3349b3666a1ea9d492f2"
+    hash="a72c97126443e62c90514f0724cdebeb3e4707a5f6812c909c2f3538905095f7"
     ;;
   bullseye)
     distro_base="Debian"
     distro_release="11"
-    hash="03a9fe62162e69df95c4a4394319110964de2cf019db3349b3666a1ea9d492f2"
+    hash="ae9b59d0d11e2ed0db9dee7e364ffb77fbcd3f03b2fc86fbf3db1e18c448b2a3"
     ;;
   *) ;;
 esac

--- a/packages/megasync-deb/megasync-deb.pacscript
+++ b/packages/megasync-deb/megasync-deb.pacscript
@@ -1,33 +1,38 @@
 name="megasync-deb"
 gives="megasync"
 repology=("project: megasync")
-pkgver="4.9.6"
-build_version="1.1"
+pkgver="4.11.0"
+build_version="3.1"
 replace=("${gives}")
 breaks=("${gives}" "${gives}-bin" "${gives}-git" "${gives}-app" "${gives}-deb")
-incompatible=("debian:sid" "*:buster" "*:stretch" "*:jessie" "debian:testing" "*:bionic" "*:focal" "*:kinetic" "*:mantic")
+incompatible=("debian:sid" "*:buster" "*:stretch" "*:jessie" "debian:testing" "*:bionic" "*:focal" "*:kinetic")
 arch=("amd64")
 
 case "${DISTRO#*:}" in
+  mantic)
+    distro_base="xUbuntu"
+    distro_release="23.10"
+    hash="375385a178bf86039c406d9f691aee187c47308e4bab11d0ea135c97c919f900"
+    ;;
   lunar)
     distro_base="xUbuntu"
     distro_release="23.04"
-    hash="5f37dacf8da5ca3efaca50fb462553d361ef34a75a553c5fcd2202f2e624b56a"
+    hash="d461cb63bb7ef78884eb562857bf6723939d72042894c27222479e76f4d658ea"
     ;;
   jammy)
     distro_base="xUbuntu"
     distro_release="22.04"
-    hash="9c7980b6f7551786daff03738528bdc70b7df5c2193953c80140af50f63b4121"
+    hash="03a9fe62162e69df95c4a4394319110964de2cf019db3349b3666a1ea9d492f2"
     ;;
   bookworm)
     distro_base="Debian"
     distro_release="12"
-    hash="083bb006cc71038e04fb90b97f6b837f0539c7f8c2f4eaa4c38890ef12c134ac"
+    hash="03a9fe62162e69df95c4a4394319110964de2cf019db3349b3666a1ea9d492f2"
     ;;
   bullseye)
     distro_base="Debian"
     distro_release="11"
-    hash="38a30c5743f250975502bde45b3fd87ffaae031ca76aa6fd69d6605cf363662c"
+    hash="03a9fe62162e69df95c4a4394319110964de2cf019db3349b3666a1ea9d492f2"
     ;;
   *) ;;
 esac


### PR DESCRIPTION
Only compatible with:

- Ubuntu 22.04 and derivatives
- Ubuntu 23.04 and derivatives
- Ubuntu 23.10 and derivatives
- Debian 11
- Debian 12
