### PR TITLE
fix(glow-deb): fix arch64 is not a valid architecture

### DIFF
--- a/packages/glow-deb/glow-deb.pacscript
+++ b/packages/glow-deb/glow-deb.pacscript
@@ -2,7 +2,7 @@ name="glow-deb"
 gives="glow"
 replace=("${gives}")
 pkgver="1.5.1"
-arch=("amd64" "arch64")
+arch=("amd64" "arm64")
 case "${CARCH}" in
   amd64)
     url="https://github.com/charmbracelet/glow/releases/download/v${pkgver}/glow_${pkgver}_amd64.deb"


### PR DESCRIPTION
Can't install `glow-deb` with `pacstall -I glow-deb` due to `[!] ERROR: 'arch64' is not a valid architecture`.