### PR TITLE
upd(oil): `0.17` -> `0.20`

### DIFF
--- a/packages/oil/oil.pacscript
+++ b/packages/oil/oil.pacscript
@@ -7,12 +7,12 @@
 maintainer="wizard-28 <wiz28@pm.me>"
 
 name="oil"
-pkgver="0.17.0"
+pkgver="0.20.0"
 pkgdesc="A bash-compatible UNIX shell written in Python"
 url="https://www.oilshell.org/download/oil-${pkgver}.tar.xz"
 gives="oil"
 breaks=("${name}-bin" "${name}-git" "${name}-deb" "${name}-app")
-hash="1fba16237fbaeb432131d0d34cf5f5d7f61a96722dce1c5f741aedc0a47cc6b3"
+hash="42b85f52bbba4a3bb8e16f23fc394c4302bcfd9638f067f01c37d23f2ee449a0"
 repology=("project: oil-shell")
 
 # Edit MAKEFLAGS here


### PR DESCRIPTION
https://www.oilshell.org/ is still unstable and making changes, so it's good to be able to follow the latest version to keep up.

Not sure of etiquette here - @wizard-28 is marked is maintainer but doesn't seem to have been around for a bit? Will mark this as a draft for a while in the hope of getting some feedback on what's best to do.

I've deployed this locally and only needed one single-line patch to one of my scripts due to an apparent syntax change - to be expected as this is explicitly an unstable package. Other than that, nothing has exploded, and upstream has a pretty heavy test suite anyway.