### PR TITLE
add: `nerd-fonts-fira-code`

### DIFF
--- a/packagelist
+++ b/packagelist
@@ -284,6 +284,7 @@ neovim
 neovim-app
 neovim-git
 nerd-fonts-cascadia-code
+nerd-fonts-fira-code
 nerd-fonts-hack
 nerd-fonts-jetbrains-mono
 nodejs-lts-deb

--- a/packages/nerd-fonts-fira-code/nerd-fonts-fira-code.pacscript
+++ b/packages/nerd-fonts-fira-code/nerd-fonts-fira-code.pacscript
@@ -1,0 +1,13 @@
+name="nerd-fonts-fira-code"
+replace=("${name}")
+repology=("project: fonts:nerd-fonts")
+pkgver="3.1.1"
+url="https://github.com/ryanoasis/nerd-fonts/releases/download/v${pkgver}/FiraCode.zip"
+pkgdesc="Patched font Fira Code from Nerd Fonts library"
+hash="1ad776cc5c186ff7ba1e2a05eea6701dfa57f7a1763e1db3422979301fb86209"
+maintainer="Nezred <jmnezred@pm.me>"
+
+package() {
+  sudo install -Dm644 ./*.ttf -t "${pkgdir}/usr/share/fonts/TTF"
+  sudo install -Dm644 "LICENSE" -t "${pkgdir}/usr/share/licenses/${name}"
+}


### PR DESCRIPTION
i tried to use a tar.xz file, but it wasnt working, is there a compatibility issue with that type of archive? for the moment, zip works.