### PR TITLE
feat(discord,discord-canary): symlink executable to PATH

### DIFF
--- a/packages/discord-canary/discord-canary.pacscript
+++ b/packages/discord-canary/discord-canary.pacscript
@@ -9,13 +9,10 @@ pkgdesc="Chat for Communities and Friends - Unstable"
 arch=('amd64')
 hash="1a63e7735dcb041b0c81389490eb2d2f5bb4976f4d1945100502939577095ac1"
 
-prepare() {
-  sudo mkdir -p "${pkgdir}/usr/share/${name}/"
-  sudo mkdir -p "${pkgdir}/usr/share/applications/"
-  sudo mkdir -p "${pkgdir}/usr/share/icons/"
-}
-
 package() {
+  sudo install -dm644 "${pkgdir}/usr/bin"
+  sudo install -dm644 "${pkgdir}/usr/share/${name}"
+  sudo ln -s "/usr/share/${name}/DiscordCanary" "${pkgdir}/usr/bin/${name}"
   sudo install -Dm755 discord-canary.desktop "${pkgdir}/usr/share/applications/discord-canary.desktop"
   sudo install -Dm755 discord.png "${pkgdir}/usr/share/icons/discord-canary.png"
   sudo cp -R ./* "${pkgdir}/usr/share/${name}/"

--- a/packages/discord/discord.pacscript
+++ b/packages/discord/discord.pacscript
@@ -9,13 +9,10 @@ hash="edc6a7d7926105ce8e240599324f2e11db7f0f5a2b08a1b530dd5605d4d9ac8d"
 arch=('amd64')
 repology=("project: ${name}")
 
-prepare() {
-  sudo mkdir -p "${pkgdir}/usr/share/discord/"
-  sudo mkdir -p "${pkgdir}/usr/share/applications/"
-  sudo mkdir -p "${pkgdir}/usr/share/icons/"
-}
-
 package() {
+  sudo install -dm644 "${pkgdir}/usr/bin"
+  sudo install -dm644 "${pkgdir}/usr/share/discord"
+  sudo ln -s /usr/share/discord/Discord "${pkgdir}/usr/bin/discord"
   sudo install -Dm755 discord.desktop "${pkgdir}/usr/share/applications/discord.desktop"
   sudo install -Dm755 discord.png "${pkgdir}/usr/share/icons/discord.png"
   sudo cp -R ./* "${pkgdir}/usr/share/discord/"


### PR DESCRIPTION
Also, move interaction with `pkgdir` out of `prepare()`, since that's highly discouraged in PKGBUILDs.