### PR TITLE
upd(an-anime-game-launcher-bin): `3.9.4` -> `3.9.5`

### DIFF
--- a/packages/an-anime-game-launcher-bin/an-anime-game-launcher-bin.pacscript
+++ b/packages/an-anime-game-launcher-bin/an-anime-game-launcher-bin.pacscript
@@ -1,10 +1,10 @@
 name="an-anime-game-launcher-bin"
 pkgname="an-anime-game-launcher"
-pkgver="3.9.4"
+pkgver="3.9.5"
 pkgdesc="Launcher for a specific anime game with auto-patching, discord rpc and time tracking"
 repology=("project: an-anime-game-launcher")
 url="https://github.com/an-anime-team/an-anime-game-launcher/releases/download/${pkgver}/anime-game-launcher"
-hash="91a1920aadee2016f9e3695b16132090eaae6c72bce4e0f6b242ea368dc01534"
+hash="b6a036ec76d4fc2573263fad61ff3ed1e937fa8bdf3e0cddfd79a8cd65e9bb55"
 depends=("xdelta3")
 maintainer="Elsie19 <elsie19@pm.me>"
 gives="${pkgname}"


### PR DESCRIPTION
Everything should be correct and An Anime Game Launcher should now be able to update to version 3.9.5 with pacstall.