### PR TITLE
add: `goverlay-bin`

### DIFF
--- a/packagelist
+++ b/packagelist
@@ -163,6 +163,7 @@ google-chrome-deb
 google-chrome-unstable-deb
 google-earth-pro-stable-deb
 goverlay
+goverlay-bin
 graillon
 grapejuice-git
 grive2

--- a/packages/goverlay-bin/goverlay-bin.pacscript
+++ b/packages/goverlay-bin/goverlay-bin.pacscript
@@ -6,7 +6,7 @@ hash="47754023d12b9eb730c83fe9aeec7b8523d1dbaa9860c90928ddaa904b89aa1f"
 depends=("mangohud" "libqt5pas-dev")
 replace=("goverlay")
 pkgdesc="Graphical UI to help manage Linux overlays"
-maintainer="Elsie19 <elsie19@pm.me>"
+maintainer="xdavius <xdavius@github.com>"
 repology=("project: goverlay")
 
 package() {

--- a/packages/goverlay-bin/goverlay-bin.pacscript
+++ b/packages/goverlay-bin/goverlay-bin.pacscript
@@ -1,0 +1,27 @@
+name="goverlay-bin"
+gives="goverlay"
+pkgver="1.0"
+url="https://github.com/benjamimgois/goverlay/releases/download/${pkgver}/goverlay_${pkgver//.*/}.tar.xz"
+hash="47754023d12b9eb730c83fe9aeec7b8523d1dbaa9860c90928ddaa904b89aa1f"
+depends=("mangohud" "libqt5pas-dev")
+replace=("goverlay")
+pkgdesc="Graphical UI to help manage Linux overlays"
+maintainer="Elsie19 <elsie19@pm.me>"
+repology=("project: goverlay")
+
+package() {
+  sudo mkdir -p "${pkgdir}/usr/bin/" "${pkgdir}/opt/goverlay/" "${pkgdir}/usr/share/applications/" "${pkgdir}/usr/share/icons/hicolor/128x128/apps/"
+  echo -e "#!/bin/sh\nQT_QPA_PLATFORM=xcb mangohud --dlsym /opt/goverlay/goverlay" | sudo tee "${pkgdir}/usr/bin/goverlay" >/dev/null
+  sudo chmod +x "${pkgdir}/usr/bin/goverlay"
+  sudo install -Dm755 goverlay "${pkgdir}/opt/goverlay/goverlay"
+  echo '[Desktop Entry]
+Name=GOverlay
+Comment=Graphical UI to help manage Vulkan / OpenGL overlays
+Exec=goverlay
+Icon=goverlay
+Terminal=false
+Type=Application
+Categories=Game;
+Keywords=MangoHud;vkBasalt;ReplaySorcery;msi;afterburner;' | sudo tee "${pkgdir}/usr/share/applications/goverlay.desktop" >/dev/null
+  sudo wget -q https://raw.githubusercontent.com/benjamimgois/goverlay/master/data/icons/128x128/goverlay.png -P "${pkgdir}/usr/share/icons/hicolor/128x128/apps/"
+}


### PR DESCRIPTION
- Original Package from Elsie19 changed to goverlay-bin
- Add replace for goverlay
- Still in QT5 version for now, not updated to latest version