### PR TITLE
add: `rio-wayland-deb` and `rio-x11-deb`

### DIFF
--- a/packagelist
+++ b/packagelist
@@ -388,6 +388,8 @@ rhino-setup-bin
 rhino-setup-git
 rhino-system-git
 rhino-ubxi-core
+rio-wayland-deb
+rio-x11-deb
 rpcs3-app
 rstudio-deb
 rust-motd-deb

--- a/packages/rio-wayland-deb/rio-wayland-deb.pacscript
+++ b/packages/rio-wayland-deb/rio-wayland-deb.pacscript
@@ -1,0 +1,9 @@
+name="rio-wayland-deb"
+gives="rio"
+breaks=("rio-x11-deb" "rio-git")
+pkgver="0.0.36"
+pkgdesc=" A hardware-accelerated GPU terminal emulator focusing to run in desktops and browsers."
+hash="754ec290a8ec3a3ec130ab4aa5b1ad9d2173620e0d7a228694a91154af9c8c2b"
+maintainer="Herisson <spaceguybox@outlook.com>"
+url="https://github.com/raphamorim/rio/releases/download/v${pkgver}/rio_${pkgver}-1_amd64_wayland.deb"
+repology=("project: ${gives}")

--- a/packages/rio-x11-deb/rio-x11-deb.pacscript
+++ b/packages/rio-x11-deb/rio-x11-deb.pacscript
@@ -1,0 +1,9 @@
+name="rio-x11-deb"
+gives="rio"
+breaks=("rio-wayland-deb" "rio-git")
+pkgver="0.0.36"
+pkgdesc=" A hardware-accelerated GPU terminal emulator focusing to run in desktops and browsers."
+hash="754ec290a8ec3a3ec130ab4aa5b1ad9d2173620e0d7a228694a91154af9c8c2b"
+maintainer="Herisson <spaceguybox@outlook.com>"
+url="https://github.com/raphamorim/rio/releases/download/v${pkgver}/rio_${pkgver}-1_amd64_wayland.deb"
+repology=("project: ${gives}")


### PR DESCRIPTION
rust based terminal emulators. sorry for the hiatus