### PR TITLE
ci(pac5-conv.yml): add temp `5.0.0` converter/branch

### DIFF
--- a/.github/workflows/pac5-conv.yml
+++ b/.github/workflows/pac5-conv.yml
@@ -1,0 +1,36 @@
+name: Convert Pacscripts to 5.0.0
+
+on:
+   workflow_dispatch:
+   push:
+     branches:
+       - master
+
+permissions:
+  contents: write
+
+jobs:
+  convert-pacscripts:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4.1.1
+
+      - name: Fetch Upstream
+        run: |
+          git remote add upstream https://github.com/pacstall/pacstall-programs
+          git fetch upstream
+          git checkout upstream/master
+
+      - name: Convert
+        run: |
+          bash -c "$(curl -fsSL https://raw.githubusercontent.com/oklopfer/debs/master/misc/pac5-conv.sh)" \
+          && echo "Success!"
+
+      - name: Commit and Push
+        run: |
+          git add packages/*/*.pacscript
+          git config --local user.name "${{ github.actor }}"
+          git config --local user.email "${{ github.actor_id }}+${{ github.actor }}@users.noreply.github.com"
+          git commit -m "refactor(*)!: convert pacscripts to \`5.0.0\` format"
+          git push origin HEAD:refs/heads/5.0.0-master --force


### PR DESCRIPTION
creates a temp CI that runs the 5.0.0 conversion script freshly on top of the latest changes to master, every time there is a push to master. 

Force pushes the converted changes to a branch `5.0.0-master` so that there is no rebasing. It will always just be the one commit on top of the latest commit to `master`; will not force push if the conversion fails.

Checks out from upstream link to ensure true master is always the one selected.

Only takes 10-15 seconds. See:
https://github.com/oklopfer/pacstall-programs/actions/runs/8463596105
https://github.com/oklopfer/pacstall-programs/commits/5.0.0-master/