### PR TITLE
ci(tests.yml): run containers privileged

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,6 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     container:
       image: ${{ matrix.OS }}
+      options: --privileged
       env:
         TERM: xterm
         shell: bash
@@ -147,6 +148,7 @@ jobs:
     runs-on: ubuntu-latest
     container:
       image: ${{ matrix.OS }}
+      options: --privileged
       env:
         TERM: xterm
         shell: bash


### PR DESCRIPTION
needed for 5.0.0 (bwrap) to run properly

technically doesn't need to be merged till 5.0.0 is released