### PR TITLE
upd(fastfetch-git): `2.6.1` -> `2.9.1`

### DIFF
--- a/packages/fastfetch-git/fastfetch-git.pacscript
+++ b/packages/fastfetch-git/fastfetch-git.pacscript
@@ -10,7 +10,7 @@ name="fastfetch-git"
 pkgname="fastfetch"
 pkgdesc="Like neofetch, but much faster because written in c"
 url="https://github.com/LinusDierheimer/fastfetch.git"
-pkgver="2.6.3"
+pkgver="2.9.1"
 makedepends=("cmake" "libpci-dev" "libvulkan-dev" "libwayland-dev" "libxrandr-dev" "libxcb-randr0-dev" "libdconf-dev" "libmagick++-dev" "libmagickcore-dev" "libdbus-1-dev" "libpci-dev" "libxfconf-0-dev" "libegl-dev" "libglx-dev" "libosmesa6-dev" "ocl-icd-opencl-dev" "libnm-dev" "libpulse-dev" "libddcutil-dev" "directx-headers-dev")
 optdepends=("libvulkan1: Vulkan module and GPU fallback"
   "libegl1: OpenGL module"


### PR DESCRIPTION
just a version number update really (the script always downloads the latest version, but it's quite confusing when doing a `pacstall -L` list and it still says `2.6.1`).