### PR TITLE
upd(chezmoi-deb): `2.45.0` -> `2.47.2`

### DIFF
--- a/packages/chezmoi-deb/chezmoi-deb.pacscript
+++ b/packages/chezmoi-deb/chezmoi-deb.pacscript
@@ -1,9 +1,9 @@
 name="chezmoi-deb"
 gives="chezmoi"
-pkgver="2.45.0"
+pkgver="2.47.2"
 url="https://github.com/twpayne/${gives}/releases/download/v${pkgver}/${gives}_${pkgver}_linux_amd64.deb"
 pkgdesc="Manage your dotfiles across multiple diverse machines, securely"
-hash="d7aa83fb019ac4de816d640d06dc1ff1c52585d5de329f2c41f29f3ea18dff03"
+hash="49a19268d29610bec619b29922468704fe4e81c0a1624d311dd84da8196cc542"
 arch=('amd64')
 maintainer="Oren Klopfer <oren@taumoda.com>"
 repology=("project: chezmoi")


### PR DESCRIPTION
Just a simple update for Chezmoi. I updated it in my fork and wanted to share. Hope you don't mind @oklopfer :smile:. 

I have updated the checksum to match the one in checksums.txt from the Github Release 2.47.2 for Chezmoi. The signature on the checksums file has been verified against the `chezmoi_cosign.pub` key using Cosign.