### PR TITLE
upd(distrobox): 1.7.0 -> 1.7.1

### DIFF
--- a/packages/distrobox/distrobox.pacscript
+++ b/packages/distrobox/distrobox.pacscript
@@ -1,9 +1,9 @@
 name="distrobox"
-pkgver="1.7.0"
+pkgver="1.7.1"
 pkgdesc="Use any linux distribution inside your terminal"
 repology=("project: distrobox")
 url="https://github.com/89luca89/distrobox/archive/refs/tags/${pkgver}.tar.gz"
-hash="ede6267a4e26c43535622e0ca3b27bc35bdeb5cbc97e551f094b852447457200"
+hash="a39ce0b579e8e7c7599b5effaf53462814d443ce5d30131e19db2f8b830f242f"
 maintainer="Marie Piontek <marie@kaifa.ch>"
 gives="${name}"
 breaks=("${name}" "${name}-deb" "${name}-app" "${name}-git")


### PR DESCRIPTION
This PR updates the `distrobox` package to the recent version `1.7.1`.