### PR TITLE
fix(qt6pas): change gives and add provides to match realname

### DIFF
--- a/packages/qt6pas/qt6pas.pacscript
+++ b/packages/qt6pas/qt6pas.pacscript
@@ -1,11 +1,12 @@
 name="qt6pas"
-gives="libqt6pas6"
+gives="libqt6pas-dev"
 pkgver="6.2.7"
 _lazarus_tag="3_0"
 _lazarus_version="3.0.0"
 url="https://gitlab.com/freepascal.org/lazarus/lazarus/-/archive/lazarus_${_lazarus_tag}/lazarus-lazarus_${_lazarus_tag}.tar.bz2"
 arch=("amd64")
 makedepends=('qt6-base-dev' 'qmake6' 'libgl-dev')
+provides=('libqt6pas1')
 hash="053ebb9d703162617a6c5bbd26e78aacb45e439d9a9964aa3197eaada2aa8c2e"
 pkgdesc="Free Pascal Qt6 binding library updated by lazarus IDE"
 maintainer="Xdavius <xdavius@github.com>"


### PR DESCRIPTION
As qt5pas was libqt5pas-dev libqt5pas1
Changed to  libqt6pas-dev libqt6pas1