### PR TITLE
feat: add .shellcheckrc, specify shell=bash, re-enable codes which are safe to enable

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,7 +18,6 @@ repos:
     hooks:
       - id: shellcheck
         types: []
-        args: ["-o", "all", "-e", "2148", "-e", "SC2033", "-e", "SC2032", "-e", "SC2034", "-e", "SC2154", "-e", "SC2312", "-e", "SC2164", "-e", "SC2143", "-e", "SC2103"]
         files: '^.*\.(pacscript|sh)$'
   - repo: https://github.com/maxwinterstein/shfmt-py
     rev: v3.7.0.1

--- a/.shellcheckrc
+++ b/.shellcheckrc
@@ -1,0 +1,22 @@
+enable=all
+shell=bash
+
+# foo appears unused. Verify it or export it.
+# https://www.shellcheck.net/wiki/SC2034
+disable=SC2034
+
+# Use a ( subshell ) to avoid having to cd back.
+# https://www.shellcheck.net/wiki/SC2103
+disable=SC2103
+
+# var is referenced but not assigned.
+# https://www.shellcheck.net/wiki/SC2154
+disable=SC2154
+
+# Use cd ... || exit in case cd fails.
+# https://www.shellcheck.net/wiki/SC2164
+disable=SC2164
+
+# Consider invoking this command separately to avoid masking its return value (or use '|| true' to ignore).
+# https://www.shellcheck.net/wiki/SC2312
+disable=SC2312

--- a/packages/docker-bin/docker-bin.pacscript
+++ b/packages/docker-bin/docker-bin.pacscript
@@ -104,10 +104,10 @@ WantedBy=multi-user.target' | tee "${pkgdir}/lib/systemd/system/containerd.servi
 }
 
 post_install() {
-  if [[ -z $(grep docker /etc/group) ]]; then
+  if ! grep -q docker /etc/group; then
     sudo groupadd docker
   fi
-  if [[ -z $(grep docker /etc/group | grep "${PACSTALL_USER}") ]]; then
+  if ! grep docker /etc/group | grep -q "${PACSTALL_USER}"; then
     sudo usermod -aG docker "${PACSTALL_USER}"
   fi
   if [[ -f /bin/systemctl ]]; then


### PR DESCRIPTION
Rationale: people constantly get confused when running shellcheck manually. This makes those invocations consistent with the pre-commit hook (which the args can be removed from now). Also suppresses redundant LSP warnings.

3 of the 4 codes I re-enabled triggered no warnings when run on all files, the fourth - only for one file, which I fixed.