### PR TITLE
upd(hamclock): `3.10` -> `4.0.0`

### DIFF
--- a/packages/hamclock/.SRCINFO
+++ b/packages/hamclock/.SRCINFO
@@ -1,8 +1,8 @@
 pkgname = hamclock
-pkgver = 3.10
+pkgver = 4.00
 pkgdesc = Clock and world map with extra features for amateur radio (800x480 version)
 url = https://clearskyinstitute.com/ham/HamClock
-source = https://github.com/kj7rrv/hamclock/archive/refs/tags/v3.10.tar.gz
+source = https://github.com/kj7rrv/hamclock/archive/refs/tags/v4.00.tar.gz
 makedepends = gcc
 makedepends = make
 makedepends = pkg-config
@@ -16,4 +16,4 @@ breaks = hamclock-huge
 replaces = hamclock
 maintainer = Roy Williams <fang64@gmail.com>
 repology = project: hamclock
-sha256sums = 49ee666ac5c2fd9c647119bf36a5d627f7fc8b1db22b0ad7140e9e60a30554c5
+sha256sums = 1def12cf34d3486edb1c4fb0ec7f1a27cc1bda01ca811b6c0fefc68c4c98ab20

--- a/packages/hamclock/hamclock.pacscript
+++ b/packages/hamclock/hamclock.pacscript
@@ -1,12 +1,12 @@
 pkgname="hamclock"
-pkgver="3.10"
+pkgver="4.00"
 source=("https://github.com/kj7rrv/hamclock/archive/refs/tags/v${pkgver}.tar.gz")
 url='https://clearskyinstitute.com/ham/HamClock'
 makedepends=("gcc" "make" "pkg-config" "libxau6" "libx11-6" "libx11-dev" "libxcb1")
 breaks=("hamclock-big" "hamclock-bigger" "hamclock-huge")
 replaces=("hamclock")
 pkgdesc="Clock and world map with extra features for amateur radio (800x480 version)"
-sha256sums=("49ee666ac5c2fd9c647119bf36a5d627f7fc8b1db22b0ad7140e9e60a30554c5")
+sha256sums=("1def12cf34d3486edb1c4fb0ec7f1a27cc1bda01ca811b6c0fefc68c4c98ab20")
 maintainer=("Roy Williams <fang64@gmail.com>")
 repology=("project: ${pkgname}")
 


### PR DESCRIPTION
I've updated the package to current release from https://clearskyinstitute.com/ham/HamClock/