### PR TITLE
ci(.pre-commit-config.yaml): locale issues with pre-commit-config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -46,6 +46,6 @@ repos:
       - id: update-packagelist
         name: update packagelist file
         language: system
-        entry: ./scripts/srcinfo.sh packagelist
+        entry: env LC_ALL=C ./scripts/srcinfo.sh packagelist
 
 # vim:set ft=yaml ts=2 sw=2 et:


### PR DESCRIPTION
This fixes a ordering issue caused by locale-specific issues in packagelist sorting.
LC_ALL=C keeps a consistent sort, whether using en_US, en_CA, or any other locale by always defining it during the pre-commit run.
