### PR TITLE
add: `docker-desktop-deb`

### DIFF
--- a/packagelist
+++ b/packagelist
@@ -92,6 +92,7 @@ doas-git
 docker-bin
 docker-buildx-plugin-bin
 docker-compose-plugin-bin
+docker-desktop-deb
 dolphin-emu-git
 dotdrop
 drawio-desktop-deb

--- a/packages/docker-desktop-deb/.SRCINFO
+++ b/packages/docker-desktop-deb/.SRCINFO
@@ -1,0 +1,12 @@
+pkgbase = docker-desktop-deb
+	gives = docker-desktop
+	pkgver = 4.33.0-160616
+	pkgdesc = Easy-to-install application that enables you to locally build and share containerized applications and microservices
+	url = https://www.docker.com/products/docker-desktop
+	arch = amd64
+	maintainer = Oren Klopfer <oren@taumoda.com>
+	repology = project: docker-desktop
+	source = https://desktop.docker.com/linux/main/amd64/160616/docker-desktop-amd64.deb
+	sha256sums = 087301fb44e421c1113389994ab5b4e50d25c9b3a0413460fa8abe1527a253fa
+
+pkgname = docker-desktop-deb

--- a/packages/docker-desktop-deb/docker-desktop-deb.pacscript
+++ b/packages/docker-desktop-deb/docker-desktop-deb.pacscript
@@ -1,0 +1,10 @@
+pkgname="docker-desktop-deb"
+gives="docker-desktop"
+pkgver="4.33.0-160616"
+arch=("amd64")
+source=("https://desktop.docker.com/linux/main/amd64/${pkgver#*-}/${gives}-amd64.deb")
+url="https://www.docker.com/products/${gives}"
+repology=("project: ${gives}")
+pkgdesc="Easy-to-install application that enables you to locally build and share containerized applications and microservices"
+maintainer=("Oren Klopfer <oren@taumoda.com>")
+sha256sums=("087301fb44e421c1113389994ab5b4e50d25c9b3a0413460fa8abe1527a253fa")

--- a/srclist
+++ b/srclist
@@ -1871,6 +1871,19 @@ pkgbase = docker-compose-plugin-bin
 
 pkgname = docker-compose-plugin-bin
 ---
+pkgbase = docker-desktop-deb
+	gives = docker-desktop
+	pkgver = 4.33.0-160616
+	pkgdesc = Easy-to-install application that enables you to locally build and share containerized applications and microservices
+	url = https://www.docker.com/products/docker-desktop
+	arch = amd64
+	maintainer = Oren Klopfer <oren@taumoda.com>
+	repology = project: docker-desktop
+	source = https://desktop.docker.com/linux/main/amd64/160616/docker-desktop-amd64.deb
+	sha256sums = 087301fb44e421c1113389994ab5b4e50d25c9b3a0413460fa8abe1527a253fa
+
+pkgname = docker-desktop-deb
+---
 pkgbase = dolphin-emu-git
 	gives = dolphin-emu
 	pkgver = 5.0


### PR DESCRIPTION
Required for https://github.com/rhino-linux/rhino-setup/pull/68