### PR TITLE
upd(the-honkers-railway-launcher-bin): `1.6.1` -> `1.7.1`

### DIFF
--- a/packages/the-honkers-railway-launcher-bin/.SRCINFO
+++ b/packages/the-honkers-railway-launcher-bin/.SRCINFO
@@ -1,8 +1,7 @@
 pkgbase = the-honkers-railway-launcher-bin
 	gives = the-honkers-railway-launcher
-	pkgver = 1.6.1
+	pkgver = 1.7.0
 	pkgdesc = The Honkers Railway launcher for Linux with automatic patching and telemetry disabling
-	depends = xdelta3
 	optdepends = mangohud: FPS Hud/GUI
 	optdepends = gamemode: Game Optimizations
 	breaks = the-honkers-railway-launcher
@@ -18,9 +17,9 @@ pkgbase = the-honkers-railway-launcher-bin
 	incompatible = debian:bullseye
 	maintainer = vbrabandt2005 <vbrabandt@proton.me>
 	repology = project: the-honkers-railway-launcher
-	source = https://github.com/an-anime-team/the-honkers-railway-launcher/releases/download/1.6.1/honkers-railway-launcher
+	source = https://github.com/an-anime-team/the-honkers-railway-launcher/releases/download/1.7.0/honkers-railway-launcher
 	source = icon.png::https://raw.githubusercontent.com/an-anime-team/the-honkers-railway-launcher/main/assets/images/icon.png
-	sha256sums = b1fecc6643014cdd352a8130ac702ecf56f3b6b1a9188040ac3ac02f2cc01f56
+	sha256sums = f6be9f0825666b871a1616c9a6c6fd677f9323191bdcfa0f8f47c234c6a1f681
 	sha256sums = SKIP
 
 pkgname = the-honkers-railway-launcher-bin

--- a/packages/the-honkers-railway-launcher-bin/.SRCINFO
+++ b/packages/the-honkers-railway-launcher-bin/.SRCINFO
@@ -1,6 +1,6 @@
 pkgbase = the-honkers-railway-launcher-bin
 	gives = the-honkers-railway-launcher
-	pkgver = 1.7.0
+	pkgver = 1.7.1
 	pkgdesc = The Honkers Railway launcher for Linux with automatic patching and telemetry disabling
 	optdepends = mangohud: FPS Hud/GUI
 	optdepends = gamemode: Game Optimizations
@@ -17,9 +17,9 @@ pkgbase = the-honkers-railway-launcher-bin
 	incompatible = debian:bullseye
 	maintainer = vbrabandt2005 <vbrabandt@proton.me>
 	repology = project: the-honkers-railway-launcher
-	source = https://github.com/an-anime-team/the-honkers-railway-launcher/releases/download/1.7.0/honkers-railway-launcher
+	source = https://github.com/an-anime-team/the-honkers-railway-launcher/releases/download/1.7.1/honkers-railway-launcher
 	source = icon.png::https://raw.githubusercontent.com/an-anime-team/the-honkers-railway-launcher/main/assets/images/icon.png
-	sha256sums = f6be9f0825666b871a1616c9a6c6fd677f9323191bdcfa0f8f47c234c6a1f681
+	sha256sums = 6ecd7c0b61d86eac7d18ef01274a8acb66ca4680a04c1fef991c734494771552
 	sha256sums = SKIP
 
 pkgname = the-honkers-railway-launcher-bin

--- a/packages/the-honkers-railway-launcher-bin/the-honkers-railway-launcher-bin.pacscript
+++ b/packages/the-honkers-railway-launcher-bin/the-honkers-railway-launcher-bin.pacscript
@@ -1,6 +1,6 @@
 pkgname="the-honkers-railway-launcher-bin"
 gives="the-honkers-railway-launcher"
-pkgver="1.7.0"
+pkgver="1.7.1"
 pkgdesc="The Honkers Railway launcher for Linux with automatic patching and telemetry disabling"
 repology=("project: the-honkers-railway-launcher")
 source=(
@@ -8,7 +8,7 @@ source=(
   "icon.png::https://raw.githubusercontent.com/an-anime-team/the-honkers-railway-launcher/main/assets/images/icon.png"
 )
 sha256sums=(
-  "f6be9f0825666b871a1616c9a6c6fd677f9323191bdcfa0f8f47c234c6a1f681"
+  "6ecd7c0b61d86eac7d18ef01274a8acb66ca4680a04c1fef991c734494771552"
   "SKIP"
 )
 maintainer=("vbrabandt2005 <vbrabandt@proton.me>")

--- a/packages/the-honkers-railway-launcher-bin/the-honkers-railway-launcher-bin.pacscript
+++ b/packages/the-honkers-railway-launcher-bin/the-honkers-railway-launcher-bin.pacscript
@@ -1,6 +1,6 @@
 pkgname="the-honkers-railway-launcher-bin"
 gives="the-honkers-railway-launcher"
-pkgver="1.6.1"
+pkgver="1.7.0"
 pkgdesc="The Honkers Railway launcher for Linux with automatic patching and telemetry disabling"
 repology=("project: the-honkers-railway-launcher")
 source=(
@@ -8,10 +8,9 @@ source=(
   "icon.png::https://raw.githubusercontent.com/an-anime-team/the-honkers-railway-launcher/main/assets/images/icon.png"
 )
 sha256sums=(
-  "b1fecc6643014cdd352a8130ac702ecf56f3b6b1a9188040ac3ac02f2cc01f56"
+  "f6be9f0825666b871a1616c9a6c6fd677f9323191bdcfa0f8f47c234c6a1f681"
   "SKIP"
 )
-depends=("xdelta3")
 maintainer=("vbrabandt2005 <vbrabandt@proton.me>")
 incompatible=("ubuntu:bionic" "ubuntu:focal" "ubuntu:jammy" "ubuntu:kinetic" "debian:stretch" "debian:buster" "debian:bullseye")
 breaks=("${gives}" "${gives}-deb" "${gives}-app" "${gives}-git")
@@ -22,7 +21,6 @@ optdepends=(
 )
 
 package() {
-  cd "${_archive}"
   install -Dm755 "honkers-railway-launcher" "${pkgdir}/usr/bin/${gives}"
   mkdir -p "${pkgdir}/usr/share/applications"
   echo '[Desktop Entry]

--- a/srclist
+++ b/srclist
@@ -9591,7 +9591,7 @@ pkgname = tgpt-bin
 ---
 pkgbase = the-honkers-railway-launcher-bin
 	gives = the-honkers-railway-launcher
-	pkgver = 1.7.0
+	pkgver = 1.7.1
 	pkgdesc = The Honkers Railway launcher for Linux with automatic patching and telemetry disabling
 	optdepends = mangohud: FPS Hud/GUI
 	optdepends = gamemode: Game Optimizations
@@ -9608,9 +9608,9 @@ pkgbase = the-honkers-railway-launcher-bin
 	incompatible = debian:bullseye
 	maintainer = vbrabandt2005 <vbrabandt@proton.me>
 	repology = project: the-honkers-railway-launcher
-	source = https://github.com/an-anime-team/the-honkers-railway-launcher/releases/download/1.7.0/honkers-railway-launcher
+	source = https://github.com/an-anime-team/the-honkers-railway-launcher/releases/download/1.7.1/honkers-railway-launcher
 	source = icon.png::https://raw.githubusercontent.com/an-anime-team/the-honkers-railway-launcher/main/assets/images/icon.png
-	sha256sums = f6be9f0825666b871a1616c9a6c6fd677f9323191bdcfa0f8f47c234c6a1f681
+	sha256sums = 6ecd7c0b61d86eac7d18ef01274a8acb66ca4680a04c1fef991c734494771552
 	sha256sums = SKIP
 
 pkgname = the-honkers-railway-launcher-bin

--- a/srclist
+++ b/srclist
@@ -9591,9 +9591,8 @@ pkgname = tgpt-bin
 ---
 pkgbase = the-honkers-railway-launcher-bin
 	gives = the-honkers-railway-launcher
-	pkgver = 1.6.1
+	pkgver = 1.7.0
 	pkgdesc = The Honkers Railway launcher for Linux with automatic patching and telemetry disabling
-	depends = xdelta3
 	optdepends = mangohud: FPS Hud/GUI
 	optdepends = gamemode: Game Optimizations
 	breaks = the-honkers-railway-launcher
@@ -9609,9 +9608,9 @@ pkgbase = the-honkers-railway-launcher-bin
 	incompatible = debian:bullseye
 	maintainer = vbrabandt2005 <vbrabandt@proton.me>
 	repology = project: the-honkers-railway-launcher
-	source = https://github.com/an-anime-team/the-honkers-railway-launcher/releases/download/1.6.1/honkers-railway-launcher
+	source = https://github.com/an-anime-team/the-honkers-railway-launcher/releases/download/1.7.0/honkers-railway-launcher
 	source = icon.png::https://raw.githubusercontent.com/an-anime-team/the-honkers-railway-launcher/main/assets/images/icon.png
-	sha256sums = b1fecc6643014cdd352a8130ac702ecf56f3b6b1a9188040ac3ac02f2cc01f56
+	sha256sums = f6be9f0825666b871a1616c9a6c6fd677f9323191bdcfa0f8f47c234c6a1f681
 	sha256sums = SKIP
 
 pkgname = the-honkers-railway-launcher-bin


### PR DESCRIPTION
- Updated to `1.7.1`
- Removed `xdelta3` as dependency
- Removed `cd "${_archive}"`

Had been tested locally, confirm working (at least on my side).