### PR TITLE
fix(opensnitch-ui-deb): remove qt-material dependency

### DIFF
--- a/packages/opensnitch-ui-deb/.SRCINFO
+++ b/packages/opensnitch-ui-deb/.SRCINFO
@@ -2,7 +2,6 @@ pkgbase = opensnitch-ui-deb
 	gives = python3-opensnitch-ui
 	pkgver = 1.6.3
 	pkgdesc = OpenSnitch is a GNU/Linux port of the Little Snitch application firewall
-	depends = qt-material
 	maintainer = echometerain <echometer@disroot.org>
 	repology = project: opensnitch-ui
 	repology = repo: nix_unstable

--- a/packages/opensnitch-ui-deb/opensnitch-ui-deb.pacscript
+++ b/packages/opensnitch-ui-deb/opensnitch-ui-deb.pacscript
@@ -1,7 +1,6 @@
 pkgname="opensnitch-ui-deb"
 pkgver="1.6.3"
 source=("https://github.com/evilsocket/opensnitch/releases/download/v${pkgver}/python3-opensnitch-ui_${pkgver}-1_all.deb")
-depends=("qt-material")
 gives="python3-opensnitch-ui"
 pkgdesc="OpenSnitch is a GNU/Linux port of the Little Snitch application firewall"
 sha256sums=("529f31d24bc162fc19930e6be0ddba16f4731dfc00d6ebab3612d22790dd8b84")

--- a/srclist
+++ b/srclist
@@ -7015,7 +7015,6 @@ pkgbase = opensnitch-ui-deb
 	gives = python3-opensnitch-ui
 	pkgver = 1.6.3
 	pkgdesc = OpenSnitch is a GNU/Linux port of the Little Snitch application firewall
-	depends = qt-material
 	maintainer = echometerain <echometer@disroot.org>
 	repology = project: opensnitch-ui
 	repology = repo: nix_unstable


### PR DESCRIPTION
someone emailed about `qt-material` not existing in the mint repos, I checked and I don't think opensnitch-ui needs this to run