### PR TITLE
upd(zed-editor-{stable,preview}-bin): add missing licenses files, bump pkgrel

### DIFF
--- a/packages/zed-editor-preview-bin/.SRCINFO
+++ b/packages/zed-editor-preview-bin/.SRCINFO
@@ -1,6 +1,7 @@
 pkgbase = zed-editor-preview-bin
 	gives = zed-editor-preview
 	pkgver = 0.155.1
+	pkgrel = 2
 	pkgdesc = A high-performance, multiplayer code editor from the creators of Atom and Tree-sitter (Preview release)
 	url = https://zed.dev
 	arch = x86_64

--- a/packages/zed-editor-preview-bin/zed-editor-preview-bin.pacscript
+++ b/packages/zed-editor-preview-bin/zed-editor-preview-bin.pacscript
@@ -1,6 +1,7 @@
 pkgname="zed-editor-preview-bin"
 pkgdesc="A high-performance, multiplayer code editor from the creators of Atom and Tree-sitter (Preview release)"
 pkgver="0.155.1"
+pkgrel="2"
 repology=("project: zed-editor")
 gives="zed-editor-preview"
 license=("GPL-3.0-or-later" "AGPL-3.0-or-later" "Apache-2.0")
@@ -31,6 +32,8 @@ package() {
   # "zed" command can conflict with /usr/sbin/zed from zfs-zed package
   sed -i "s/Exec=zed/Exec=${gives}/g" "${pkgdir}/usr/share/applications/${_desktop}"
   sed -i "s/Icon=zed/Icon=${gives}/g" "${pkgdir}/usr/share/applications/${_desktop}"
+
+  install -Dm644 "zed-${_channel}.app/licenses.md" -t "${pkgdir}/usr/share/doc/${gives}/"
 
   mkdir -p "${pkgdir}/usr/bin"
   # ZED_UPDATE_EXPLANATION blocks auto-updates and is used to inform the user

--- a/packages/zed-editor-stable-bin/.SRCINFO
+++ b/packages/zed-editor-stable-bin/.SRCINFO
@@ -1,6 +1,7 @@
 pkgbase = zed-editor-stable-bin
 	gives = zed-editor
 	pkgver = 0.154.3
+	pkgrel = 2
 	pkgdesc = A high-performance, multiplayer code editor from the creators of Atom and Tree-sitter
 	url = https://zed.dev
 	arch = x86_64

--- a/packages/zed-editor-stable-bin/zed-editor-stable-bin.pacscript
+++ b/packages/zed-editor-stable-bin/zed-editor-stable-bin.pacscript
@@ -1,6 +1,7 @@
 pkgname="zed-editor-stable-bin"
 pkgdesc="A high-performance, multiplayer code editor from the creators of Atom and Tree-sitter"
 pkgver="0.154.3"
+pkgrel="2"
 repology=("project: zed-editor")
 gives="zed-editor"
 license=("GPL-3.0-or-later" "AGPL-3.0-or-later" "Apache-2.0")
@@ -31,6 +32,8 @@ package() {
   # "zed" command can conflict with /usr/sbin/zed from zfs-zed package
   sed -i "s/Exec=zed/Exec=${gives}/g" "${pkgdir}/usr/share/applications/${_desktop}"
   sed -i "s/Icon=zed/Icon=${gives}/g" "${pkgdir}/usr/share/applications/${_desktop}"
+
+  install -Dm644 "zed.app/licenses.md" -t "${pkgdir}/usr/share/doc/${gives}/"
 
   mkdir -p "${pkgdir}/usr/bin"
   # ZED_UPDATE_EXPLANATION blocks auto-updates and is used to inform the user

--- a/srclist
+++ b/srclist
@@ -12113,6 +12113,7 @@ pkgname = zed-editor-preview-bin
 pkgbase = zed-editor-stable-bin
 	gives = zed-editor
 	pkgver = 0.154.3
+	pkgrel = 2
 	pkgdesc = A high-performance, multiplayer code editor from the creators of Atom and Tree-sitter
 	url = https://zed.dev
 	arch = x86_64

--- a/srclist
+++ b/srclist
@@ -12094,6 +12094,7 @@ pkgname = zap
 pkgbase = zed-editor-preview-bin
 	gives = zed-editor-preview
 	pkgver = 0.155.1
+	pkgrel = 2
 	pkgdesc = A high-performance, multiplayer code editor from the creators of Atom and Tree-sitter (Preview release)
 	url = https://zed.dev
 	arch = x86_64


### PR DESCRIPTION
As requested here: https://github.com/zed-industries/zed/pull/18576#issuecomment-2385724834

Sorry! I missed this file when inspecting archives to create packages.