### PR TITLE
fix(`linux-modules-lts-6.6-deb`): Following what @oklopfer says

### DIFF
--- a/packagelist
+++ b/packagelist
@@ -299,7 +299,7 @@ linux-image-unsigned-stable-deb
 linux-kernel
 linux-kernel-stable
 linux-libc-dev-okpine-deb
-linux-longterm-6.6-modules-deb
+linux-modules-lts-6.6-deb
 linux-modules-deb
 linux-modules-stable-deb
 linux-wifi-hotspot-deb

--- a/packagelist
+++ b/packagelist
@@ -299,8 +299,9 @@ linux-image-unsigned-stable-deb
 linux-kernel
 linux-kernel-stable
 linux-libc-dev-okpine-deb
-linux-modules-lts-6.6-deb
+linux-longterm-6.6-modules-deb
 linux-modules-deb
+linux-modules-lts-6.6-deb
 linux-modules-stable-deb
 linux-wifi-hotspot-deb
 lix-git

--- a/packages/linux-modules-lts-6.6-deb/linux-modules-lts-6.6-deb.pacscript
+++ b/packages/linux-modules-lts-6.6-deb/linux-modules-lts-6.6-deb.pacscript
@@ -1,4 +1,4 @@
-pkgname="linux-longterm-6.6-modules-deb"
+pkgname="linux-modules-lts-6.6-deb"
 gives="linux-modules-6.6.51-060651-generic"
 pkgver="6.6.51"
 buildver="6.6.51-060651.202409121031"

--- a/srclist
+++ b/srclist
@@ -6148,6 +6148,23 @@ pkgbase = linux-modules-deb
 
 pkgname = linux-modules-deb
 ---
+pkgbase = linux-modules-lts-6.6-deb
+	gives = linux-modules-6.6.51-060651-generic
+	pkgver = 6.6.51
+	pkgdesc = Linux kernel LTS from Ubuntu Mainline Kernel PPA (modules)
+	arch = arm64
+	arch = amd64
+	maintainer = James Ed Randson <jimedrand@disroot.org>
+	repology = project: linux
+	repology = srcname: linux-mainline
+	repology = binname: linux-mainline
+	source_arm64 = https://kernel.ubuntu.com/mainline/v6.6.51/arm64/linux-modules-6.6.51-060651-generic_6.6.51-060651.202409121031_arm64.deb
+	sha256sums_arm64 = 137fa692ad93cc62203c506e871d9e1f19c8febb709c5972c6240c1bd8ae1810
+	source_amd64 = https://kernel.ubuntu.com/mainline/v6.6.51/amd64/linux-modules-6.6.51-060651-generic_6.6.51-060651.202409121031_amd64.deb
+	sha256sums_amd64 = e76d998a6ef4e40bfe60eb3494589cb4f5c4457092427697bb97d253a304246f
+
+pkgname = linux-modules-lts-6.6-deb
+---
 pkgbase = linux-modules-stable-deb
 	gives = linux-modules-6.11.0-061100-generic
 	pkgver = 6.11


### PR DESCRIPTION
Following what @oklopfer says anyway for fixing the modules. But firsts, merge the commit #6619 before merge this commit