### PR TITLE
ref(*): drop `_archive` usage from all `-app` packages

### DIFF
--- a/packages/bazecor-app/bazecor-app.pacscript
+++ b/packages/bazecor-app/bazecor-app.pacscript
@@ -17,7 +17,7 @@ maintainer=("Elsie19 <elsie19@pm.me>")
 repology=("project: bazecor")
 
 package() {
-  cd "${_archive}"
+  cd "${srcdir}"
   mkdir -p "${pkgdir}/usr/share/icons/hicolor/256x256/apps/" "${pkgdir}/usr/share/applications/"
   echo "[Desktop Entry]
 Name=Bazecor

--- a/packages/joplin-desktop-app/joplin-desktop-app.pacscript
+++ b/packages/joplin-desktop-app/joplin-desktop-app.pacscript
@@ -19,7 +19,7 @@ arch=("amd64")
 maintainer=("lfromanini <lfromanini@yahoo.com>")
 
 package() {
-  cd "${_archive}"
+  cd "${srcdir}"
   install -Dm755 "Joplin-${pkgver}.AppImage" "${pkgdir}/usr/bin/${gives}"
   install -Dm644 "${srcdir}/joplin-desktop.png" "${pkgdir}/usr/share/pixmaps/joplin-desktop.png"
   mkdir -p "${pkgdir}/usr/share/applications/"

--- a/packages/krita-app/krita-app.pacscript
+++ b/packages/krita-app/krita-app.pacscript
@@ -16,7 +16,7 @@ arch=("amd64")
 maintainer=("harrietobrien <harrietobrien@protonmail.com>")
 
 package() {
-  cd "${_archive}"
+  cd "${srcdir}"
   chmod +x "${gives}-${pkgver}-x86_64.appimage"
   install -Dm755 "${gives}-${pkgver}-x86_64.appimage" "${pkgdir}/usr/bin/${gives}"
   install -Dm644 "${srcdir}/krita.svgz" "${pkgdir}/usr/share/pixmaps/krita.svgz"

--- a/packages/librewolf-app/librewolf-app.pacscript
+++ b/packages/librewolf-app/librewolf-app.pacscript
@@ -37,7 +37,7 @@ package() {
     gnuarch="aarch64"
   fi
 
-  cd "${_archive}"
+  cd "${srcdir}"
   # Install appimage
   install -Dm755 "LibreWolf.${gnuarch}.AppImage" "${pkgdir}/usr/bin/${gives}"
 

--- a/packages/lunarclient-app/lunarclient-app.pacscript
+++ b/packages/lunarclient-app/lunarclient-app.pacscript
@@ -24,12 +24,12 @@ sha256sums=(
 )
 
 build() {
-  cd "${_archive}"
+  cd "${srcdir}"
   sed -i "s/REPLACE_VERSION/${pkgver}/" "${srcdir}/${_gives}.desktop"
 }
 
 package() {
-  cd "${_archive}"
+  cd "${srcdir}"
   # AppImage
   install -Dm755 \
     "${_appimage}" \

--- a/packages/minecraft-pi-reborn-app/.SRCINFO
+++ b/packages/minecraft-pi-reborn-app/.SRCINFO
@@ -3,6 +3,7 @@ pkgbase = minecraft-pi-reborn-app
 	pkgver = 2.5.3
 	pkgdesc = Minecraft Pi edition reborn with new features and for x86 pc.
 	arch = amd64
+	makedepends = desktop-file-utils
 	breaks = minecraft-pi-reborn-git
 	breaks = minecraft-pi-reborn-deb
 	breaks = minecraft-pi-reborn-bin

--- a/packages/minecraft-pi-reborn-app/minecraft-pi-reborn-app.pacscript
+++ b/packages/minecraft-pi-reborn-app/minecraft-pi-reborn-app.pacscript
@@ -32,5 +32,8 @@ package() {
   install -Dm644 "${srcdir}/com.thebrokenrail.MCPIRebornClient.desktop" "${pkgdir}/usr/share/applications/com.thebrokenrail.MCPIRebornClient.desktop"
   install -Dm644 "${srcdir}/com.thebrokenrail.MCPIRebornClient.appdata.xml" "${pkgdir}/usr/share/metainfo/com.thebrokenrail.MCPIRebornClient.appdata.xml"
   install -Dm644 "${srcdir}/icon.png" "${pkgdir}/usr/share/icons/hicolor/256x256/apps/com.thebrokenrail.MCPIRebornClient.png"
+}
+
+post_install() {
   update-desktop-database -q
 }

--- a/packages/minecraft-pi-reborn-app/minecraft-pi-reborn-app.pacscript
+++ b/packages/minecraft-pi-reborn-app/minecraft-pi-reborn-app.pacscript
@@ -3,6 +3,7 @@ gives="minecraft-pi-reborn"
 pkgver="2.5.3"
 breaks=("${gives}-git" "${gives}-deb" "${gives}-bin" "minecraft-pi-reborn-client")
 pkgdesc="Minecraft Pi edition reborn with new features and for x86 pc."
+makedepends=('desktop-file-utils')
 sha256sums=(
   "f00e77a85fbab907af274416fb1c4b78216c1c49a992eeeb54378269a5171156"
   "SKIP"

--- a/packages/minecraft-pi-reborn-app/minecraft-pi-reborn-app.pacscript
+++ b/packages/minecraft-pi-reborn-app/minecraft-pi-reborn-app.pacscript
@@ -20,12 +20,12 @@ maintainer=("cat-master21 <96554164+cat-master21@users.noreply.github.com>")
 repology=("project: ${gives}")
 
 prepare() {
-  cd "${_archive}"
+  cd "${srcdir}"
   mkdir -p "${pkgdir}/usr/bin" "${pkgdir}/usr/share/metainfo" "${pkgdir}/usr/share/applications" "${pkgdir}/usr/share/icons/hicolor/256x256/apps"
 }
 
 package() {
-  cd "${_archive}"
+  cd "${srcdir}"
   install -Dm644 "minecraft-pi-reborn-client-${pkgver}-amd64.AppImage" "${pkgdir}/usr/bin/minecraft-pi-reborn-client"
   chmod +x "${pkgdir}/usr/bin/minecraft-pi-reborn-client"
   install -Dm644 "${srcdir}/com.thebrokenrail.MCPIRebornClient.desktop" "${pkgdir}/usr/share/applications/com.thebrokenrail.MCPIRebornClient.desktop"

--- a/packages/mymonero-app/mymonero-app.pacscript
+++ b/packages/mymonero-app/mymonero-app.pacscript
@@ -17,7 +17,7 @@ maintainer=("Elsie19 <elsie19@pm.me>")
 repology=("project: mymonero")
 
 package() {
-  cd "${_archive}"
+  cd "${srcdir}"
   install -Dm755 "MyMonero-${pkgver}.AppImage" "${pkgdir}/usr/bin/mymonero"
   install -Dm644 "${srcdir}/MyMonero.png" "${pkgdir}/usr/share/pixmaps/MyMonero.png"
   mkdir -p "${pkgdir}/usr/share/applications/"

--- a/packages/neovim-app/neovim-app.pacscript
+++ b/packages/neovim-app/neovim-app.pacscript
@@ -13,7 +13,7 @@ repology=("project: neovim")
 maintainer=("Elsie19 <elsie19@pm.me>")
 
 package() {
-  cd "${_archive}"
+  cd "${srcdir}"
   chmod +x nvim.appimage
   install -Dm755 "nvim.appimage" "${pkgdir}/usr/bin/nvim"
 }

--- a/packages/rpcs3-app/rpcs3-app.pacscript
+++ b/packages/rpcs3-app/rpcs3-app.pacscript
@@ -10,7 +10,7 @@ maintainer=("Thomas Crha <thomas@9bitbyte.com>")
 sha256sums=("470a2998e2f8e545aa3975043983794dcd1a1f07464899b156c9cb32b2dfe2b2")
 
 package() {
-  cd "${_archive}"
+  cd "${srcdir}"
   install -Dm755 "rpcs3-v${pkgver}-${pkgsha:0:8}_linux64.AppImage" "${pkgdir}/usr/bin/rpcs3"
 }
 # vim:set ft=sh ts=2 sw=2 et:

--- a/packages/suyu-app/suyu-app.pacscript
+++ b/packages/suyu-app/suyu-app.pacscript
@@ -14,7 +14,7 @@ maintainer=("vigress8 <vig@disroot.org>")
 repology=("project: ${gives}")
 
 package() {
-  cd "${_archive}"
+  cd "${srcdir}"
   chmod +x "${appimage}"
   ./"${appimage}" --appimage-extract usr/share
   cp -a squashfs-root/usr "${pkgdir}"

--- a/packages/texstudio-app/texstudio-app.pacscript
+++ b/packages/texstudio-app/texstudio-app.pacscript
@@ -12,7 +12,7 @@ repology=("project: ${gives}")
 maintainer=("vigress8 <vig@disroot.org>")
 
 package() {
-  cd "${_archive}"
+  cd "${srcdir}"
   chmod +x "${appimage}"
   ./"${appimage}" --appimage-extract "${gives}.desktop" &> /dev/null
   ./"${appimage}" --appimage-extract "${gives}.svg" &> /dev/null

--- a/packages/tutanota-app/tutanota-app.pacscript
+++ b/packages/tutanota-app/tutanota-app.pacscript
@@ -21,7 +21,7 @@ repology=("project: tutanota" "repo: homebrew_casks")
 
 __created_desktop_file="yes"
 package() {
-  cd "${_archive}"
+  cd "${srcdir}"
   # Install AppImage
   install -Dm755 "tutanota-desktop-linux.AppImage" "${pkgdir}/usr/bin/${gives}"
 

--- a/packages/upscayl-app/upscayl-app.pacscript
+++ b/packages/upscayl-app/upscayl-app.pacscript
@@ -18,7 +18,7 @@ breaks=("${gives}" "${gives}-deb" "${gives}-bin" "${gives}-git")
 repology=("project: ${gives}")
 
 package() {
-  cd "${_archive}"
+  cd "${srcdir}"
   # Install appimage
   install -Dm755 "Upscayl-${pkgver}-linux.AppImage" "${pkgdir}/usr/bin/${gives}"
 

--- a/packages/walc-app/walc-app.pacscript
+++ b/packages/walc-app/walc-app.pacscript
@@ -16,7 +16,7 @@ sha256sums=("6c1e5c004e9c4bc5a8cf15837ce0e6c884fb3ace6397aa6aa95a6738c1960560")
 breaks=("${gives}" "${gives}-bin" "${gives}-git" "${gives}-deb")
 
 package() {
-  cd "${_archive}"
+  cd "${srcdir}"
   # Install binary
   install -Dm755 "${gives}.AppImage" "${pkgdir}/usr/bin/${gives}"
 }

--- a/srclist
+++ b/srclist
@@ -6805,6 +6805,7 @@ pkgbase = minecraft-pi-reborn-app
 	pkgver = 2.5.3
 	pkgdesc = Minecraft Pi edition reborn with new features and for x86 pc.
 	arch = amd64
+	makedepends = desktop-file-utils
 	breaks = minecraft-pi-reborn-git
 	breaks = minecraft-pi-reborn-deb
 	breaks = minecraft-pi-reborn-bin


### PR DESCRIPTION
`_archive` will never be enterable because it is an appimage, so it is unneeded
just say `cd "${srcdir}"` for clarity sake, though this is also redundant as each functions starts in `srcdir`