### PR TITLE
upd(vscodium-deb): `1.95.2.24313` -> `1.95.3.24321`

### DIFF
--- a/packages/vscodium-deb/.SRCINFO
+++ b/packages/vscodium-deb/.SRCINFO
@@ -1,6 +1,6 @@
 pkgbase = vscodium-deb
 	gives = codium
-	pkgver = 1.95.2.24313
+	pkgver = 1.95.3.24321
 	pkgdesc = Binary releases of VS Code without MS branding/telemetry/licensing
 	arch = arm64
 	arch = amd64
@@ -8,9 +8,9 @@ pkgbase = vscodium-deb
 	maintainer = Oren Klopfer <oren@taumoda.com>
 	maintainer = James Ed Randson <jimedrand@disroot.org>
 	repology = project: vscodium
-	source_arm64 = https://github.com/VSCodium/vscodium/releases/download/1.95.2.24313/codium_1.95.2.24313_arm64.deb
-	sha256sums_arm64 = 9954a9b9e719f3ebf77738dc7ef6495507bb4902f60d4e17b496759d7aad7323
-	source_amd64 = https://github.com/VSCodium/vscodium/releases/download/1.95.2.24313/codium_1.95.2.24313_amd64.deb
-	sha256sums_amd64 = 4b928209297407b4e78c8fcb9e2e72fb04a91f096f0f4fdf5e908cbc9ca1ba03
+	source_arm64 = https://github.com/VSCodium/vscodium/releases/download/1.95.3.24321/codium_1.95.3.24321_arm64.deb
+	sha256sums_arm64 = d80af1cafb789ce013698b865fb9913bcf3c6e80ca835654fbdb2e013d6f5f08
+	source_amd64 = https://github.com/VSCodium/vscodium/releases/download/1.95.3.24321/codium_1.95.3.24321_amd64.deb
+	sha256sums_amd64 = 040071c99efea5bbc04197d7274b27f7e1ed8f0acdc15da0617055589dbe3617
 
 pkgname = vscodium-deb

--- a/packages/vscodium-deb/vscodium-deb.pacscript
+++ b/packages/vscodium-deb/vscodium-deb.pacscript
@@ -1,10 +1,10 @@
 pkgname="vscodium-deb"
 gives="codium"
 breaks=("${gives}")
-pkgver="1.95.2.24313"
+pkgver="1.95.3.24321"
 arch=("arm64" "amd64")
-sha256sums_arm64=("9954a9b9e719f3ebf77738dc7ef6495507bb4902f60d4e17b496759d7aad7323")
-sha256sums_amd64=("4b928209297407b4e78c8fcb9e2e72fb04a91f096f0f4fdf5e908cbc9ca1ba03")
+sha256sums_arm64=("d80af1cafb789ce013698b865fb9913bcf3c6e80ca835654fbdb2e013d6f5f08")
+sha256sums_amd64=("040071c99efea5bbc04197d7274b27f7e1ed8f0acdc15da0617055589dbe3617")
 source_arm64=("https://github.com/VSCodium/vscodium/releases/download/${pkgver}/${gives}_${pkgver}_arm64.deb")
 source_amd64=("https://github.com/VSCodium/vscodium/releases/download/${pkgver}/${gives}_${pkgver}_amd64.deb")
 repology=("project: vscodium")

--- a/srclist
+++ b/srclist
@@ -11863,7 +11863,7 @@ pkgname = vscode-insiders-deb
 ---
 pkgbase = vscodium-deb
 	gives = codium
-	pkgver = 1.95.2.24313
+	pkgver = 1.95.3.24321
 	pkgdesc = Binary releases of VS Code without MS branding/telemetry/licensing
 	arch = arm64
 	arch = amd64
@@ -11871,10 +11871,10 @@ pkgbase = vscodium-deb
 	maintainer = Oren Klopfer <oren@taumoda.com>
 	maintainer = James Ed Randson <jimedrand@disroot.org>
 	repology = project: vscodium
-	source_arm64 = https://github.com/VSCodium/vscodium/releases/download/1.95.2.24313/codium_1.95.2.24313_arm64.deb
-	sha256sums_arm64 = 9954a9b9e719f3ebf77738dc7ef6495507bb4902f60d4e17b496759d7aad7323
-	source_amd64 = https://github.com/VSCodium/vscodium/releases/download/1.95.2.24313/codium_1.95.2.24313_amd64.deb
-	sha256sums_amd64 = 4b928209297407b4e78c8fcb9e2e72fb04a91f096f0f4fdf5e908cbc9ca1ba03
+	source_arm64 = https://github.com/VSCodium/vscodium/releases/download/1.95.3.24321/codium_1.95.3.24321_arm64.deb
+	sha256sums_arm64 = d80af1cafb789ce013698b865fb9913bcf3c6e80ca835654fbdb2e013d6f5f08
+	source_amd64 = https://github.com/VSCodium/vscodium/releases/download/1.95.3.24321/codium_1.95.3.24321_amd64.deb
+	sha256sums_amd64 = 040071c99efea5bbc04197d7274b27f7e1ed8f0acdc15da0617055589dbe3617
 
 pkgname = vscodium-deb
 ---


### PR DESCRIPTION
Another updates again for VSCodium which now had enter 1.95.3