### PR TITLE
fix(helix): Also make a symlink to the actual package name

### DIFF
--- a/packages/helix/.SRCINFO
+++ b/packages/helix/.SRCINFO
@@ -1,5 +1,6 @@
 pkgbase = helix
 	pkgver = 24.07
+	pkgrel = 2
 	pkgdesc = A post-modern modal text editor
 	arch = any
 	makedepends = cargo

--- a/packages/helix/helix.pacscript
+++ b/packages/helix/helix.pacscript
@@ -1,6 +1,7 @@
 pkgname="helix"
 arch=("any")
 pkgver="24.07"
+pkgrel="2"
 repology=("project: helix")
 source=("@${pkgname}~${pkgver}::https://github.com/helix-editor/helix/releases/download/${pkgver}/helix-${pkgver}-source.tar.xz")
 makedepends=("cargo")
@@ -19,6 +20,7 @@ package() {
 
   printf '#!/bin/sh\nHELIX_RUNTIME=/usr/lib/helix/runtime exec /usr/lib/helix/hx "$@"\n' > hx
   install -Dm755 hx -t "${pkgdir}/usr/bin"
+  ln -sf /usr/bin/hx "${pkgdir}/usr/bin/helix"
 
   rm -f runtime/grammars/.gitkeep
   rm -f runtime/themes/README.md

--- a/srclist
+++ b/srclist
@@ -4362,6 +4362,7 @@ pkgname = headset-deb
 ---
 pkgbase = helix
 	pkgver = 24.07
+	pkgrel = 2
 	pkgdesc = A post-modern modal text editor
 	arch = any
 	makedepends = cargo


### PR DESCRIPTION
This somewhat aligns the behavior with other packaging of Helix,
such as Snap and Archlinux.
