### PR TITLE
fix(vscodium-bin): fix the sums on second sources due dynamically downloads

### DIFF
--- a/packages/vscodium-bin/.SRCINFO
+++ b/packages/vscodium-bin/.SRCINFO
@@ -8,6 +8,6 @@ pkgbase = vscodium-bin
 	source = https://github.com/VSCodium/vscodium/releases/download/1.96.4.25017/VSCodium-linux-x64-1.96.4.25017.tar.gz
 	source = https://vscodium.com/img/codium_cnl.svg
 	sha256sums = c5b78556cb0674fa7de0e349c13adbc2028e6080fd04d7c3ff1a8ed541421cd1
-	sha256sums = 9817036bd2f5add672e707da311a301033ad122d6c2c505c776cb48d35b94472
+	sha256sums = SKIP
 
 pkgname = vscodium-bin

--- a/packages/vscodium-bin/vscodium-bin.pacscript
+++ b/packages/vscodium-bin/vscodium-bin.pacscript
@@ -10,7 +10,7 @@ source=(
 )
 sha256sums=(
   "c5b78556cb0674fa7de0e349c13adbc2028e6080fd04d7c3ff1a8ed541421cd1"
-  "9817036bd2f5add672e707da311a301033ad122d6c2c505c776cb48d35b94472"
+  "SKIP"
 )
 repology=("project: ${gives}")
 

--- a/srclist
+++ b/srclist
@@ -13181,7 +13181,7 @@ pkgbase = vscodium-bin
 	source = https://github.com/VSCodium/vscodium/releases/download/1.96.4.25017/VSCodium-linux-x64-1.96.4.25017.tar.gz
 	source = https://vscodium.com/img/codium_cnl.svg
 	sha256sums = c5b78556cb0674fa7de0e349c13adbc2028e6080fd04d7c3ff1a8ed541421cd1
-	sha256sums = 9817036bd2f5add672e707da311a301033ad122d6c2c505c776cb48d35b94472
+	sha256sums = SKIP
 
 pkgname = vscodium-bin
 ---


### PR DESCRIPTION
Just minor fixes for second sources. Reasons are in titles.