### PR TITLE
upd(hamclock{,-big,-bigger,-huge}): `4.11` -> `4.13`

### DIFF
--- a/packages/hamclock-big/.SRCINFO
+++ b/packages/hamclock-big/.SRCINFO
@@ -1,5 +1,5 @@
 pkgbase = hamclock-big
-	pkgver = 4.11
+	pkgver = 4.13
 	pkgrel = 3
 	pkgdesc = Clock and world map with extra features for amateur radio (1600x960 version)
 	url = https://clearskyinstitute.com/ham/HamClock
@@ -20,9 +20,9 @@ pkgbase = hamclock-big
 	replaces = hamclock-huge
 	maintainer = Roy Williams <fang64@gmail.com>
 	repology = project: hamclock-big
-	source = https://github.com/fang64/hamclock/archive/refs/tags/v4.11.tar.gz
+	source = https://github.com/fang64/hamclock/archive/refs/tags/v4.13.tar.gz
 	source = hamclock.desktop
-	sha256sums = a1f62e092df338ce044173aa62e09a7283687d1cf0173f6bc972af2bcffbff7c
+	sha256sums = d17b34a3b8b1765b84a95e01ab96b0b0e0a4eccc5958e0987e75e919991cc2c7
 	sha256sums = df56e16e9bfab4a6259fd8e9fdffbe8f8d24ff395d2d27434dfd4bfe4adfa85d
 
 pkgname = hamclock-big

--- a/packages/hamclock-big/hamclock-big.pacscript
+++ b/packages/hamclock-big/hamclock-big.pacscript
@@ -1,6 +1,6 @@
 pkgname="hamclock-big"
 arch=("any")
-pkgver="4.11"
+pkgver="4.13"
 pkgrel="3"
 source=(
   "https://github.com/fang64/hamclock/archive/refs/tags/v${pkgver}.tar.gz"
@@ -12,7 +12,7 @@ breaks=("hamclock" "hamclock-bigger" "hamclock-huge")
 replaces=("hamclock-big" "${breaks[@]}")
 pkgdesc="Clock and world map with extra features for amateur radio (1600x960 version)"
 sha256sums=(
-  "a1f62e092df338ce044173aa62e09a7283687d1cf0173f6bc972af2bcffbff7c"
+  "d17b34a3b8b1765b84a95e01ab96b0b0e0a4eccc5958e0987e75e919991cc2c7"
   "df56e16e9bfab4a6259fd8e9fdffbe8f8d24ff395d2d27434dfd4bfe4adfa85d"
 )
 maintainer=("Roy Williams <fang64@gmail.com>")
@@ -21,11 +21,10 @@ repology=("project: ${pkgname}")
 prepare() {
   cd "hamclock-${pkgver}/ESPHamClock"
   # Add -PAC to version for PACSTALL
-  sed -i 's/"/-PAC"/g' version.h
-  sed -i 's/\t-PAC"/\t"/g' version.h
+  sed -i 's/";/-PAC";/g' version.cpp
 
   # Do not check for/install updates
-  sed -i "s/tft.print (F(\"You're up to date\!\"));"'/tft.print(F("Updates disabled for PACSTALL")); tft.setCursor (tft.width()\/8, tft.height()\/3+40); tft.print(F("If this build is outdated by more than a few days,")); tft.setCursor (tft.width()\/8, tft.height()\/3+80); tft.print(F("please email fang64@gmail.com.")); wdDelay(2000);/g' ESPHamClock.ino
+  sed -i "s/tft.print (\"You're up to date\!\");"' \+\/\/[a-z ]*/tft.print("Updates disabled for PACSTALL"); tft.setCursor (tft.width()\/8, tft.height()\/3+40); tft.print("If this build is outdated by more than a few days,"); tft.setCursor (tft.width()\/8, tft.height()\/3+80); tft.print("please email fang64@gmail.com."); wdDelay(2000);/g' ESPHamClock.cpp
   sed -i 's/bool found_newer = false;/return false;bool found_newer;/g' OTAupdate.cpp
 }
 

--- a/packages/hamclock-bigger/.SRCINFO
+++ b/packages/hamclock-bigger/.SRCINFO
@@ -1,5 +1,5 @@
 pkgbase = hamclock-bigger
-	pkgver = 4.11
+	pkgver = 4.13
 	pkgdesc = Clock and world map with extra features for amateur radio (2400x1440 version)
 	url = https://clearskyinstitute.com/ham/HamClock
 	arch = any
@@ -19,9 +19,9 @@ pkgbase = hamclock-bigger
 	replaces = hamclock-huge
 	maintainer = Roy Williams <fang64@gmail.com>
 	repology = project: hamclock-bigger
-	source = https://github.com/fang64/hamclock/archive/refs/tags/v4.11.tar.gz
+	source = https://github.com/fang64/hamclock/archive/refs/tags/v4.13.tar.gz
 	source = hamclock.desktop
-	sha256sums = a1f62e092df338ce044173aa62e09a7283687d1cf0173f6bc972af2bcffbff7c
+	sha256sums = d17b34a3b8b1765b84a95e01ab96b0b0e0a4eccc5958e0987e75e919991cc2c7
 	sha256sums = df56e16e9bfab4a6259fd8e9fdffbe8f8d24ff395d2d27434dfd4bfe4adfa85d
 
 pkgname = hamclock-bigger

--- a/packages/hamclock-bigger/hamclock-bigger.pacscript
+++ b/packages/hamclock-bigger/hamclock-bigger.pacscript
@@ -1,6 +1,6 @@
 pkgname="hamclock-bigger"
 arch=("any")
-pkgver="4.11"
+pkgver="4.13"
 source=(
   "https://github.com/fang64/hamclock/archive/refs/tags/v${pkgver}.tar.gz"
   "hamclock.desktop"
@@ -11,7 +11,7 @@ breaks=("hamclock" "hamclock-big" "hamclock-huge")
 replaces=("hamclock-bigger" "${breaks[@]}")
 pkgdesc="Clock and world map with extra features for amateur radio (2400x1440 version)"
 sha256sums=(
-  "a1f62e092df338ce044173aa62e09a7283687d1cf0173f6bc972af2bcffbff7c"
+  "d17b34a3b8b1765b84a95e01ab96b0b0e0a4eccc5958e0987e75e919991cc2c7"
   "df56e16e9bfab4a6259fd8e9fdffbe8f8d24ff395d2d27434dfd4bfe4adfa85d"
 )
 maintainer=("Roy Williams <fang64@gmail.com>")
@@ -20,11 +20,10 @@ repology=("project: ${pkgname}")
 prepare() {
   cd "hamclock-${pkgver}/ESPHamClock"
   # Add -PAC to version for PACSTALL
-  sed -i 's/"/-PAC"/g' version.h
-  sed -i 's/\t-PAC"/\t"/g' version.h
+  sed -i 's/";/-PAC";/g' version.cpp
 
   # Do not check for/install updates
-  sed -i "s/tft.print (F(\"You're up to date\!\"));"'/tft.print(F("Updates disabled for PACSTALL")); tft.setCursor (tft.width()\/8, tft.height()\/3+40); tft.print(F("If this build is outdated by more than a few days,")); tft.setCursor (tft.width()\/8, tft.height()\/3+80); tft.print(F("please email fang64@gmail.com.")); wdDelay(2000);/g' ESPHamClock.ino
+  sed -i "s/tft.print (\"You're up to date\!\");"' \+\/\/[a-z ]*/tft.print("Updates disabled for PACSTALL"); tft.setCursor (tft.width()\/8, tft.height()\/3+40); tft.print("If this build is outdated by more than a few days,"); tft.setCursor (tft.width()\/8, tft.height()\/3+80); tft.print("please email fang64@gmail.com."); wdDelay(2000);/g' ESPHamClock.cpp
   sed -i 's/bool found_newer = false;/return false;bool found_newer;/g' OTAupdate.cpp
 }
 

--- a/packages/hamclock-huge/.SRCINFO
+++ b/packages/hamclock-huge/.SRCINFO
@@ -1,5 +1,5 @@
 pkgbase = hamclock-huge
-	pkgver = 4.11
+	pkgver = 4.13
 	pkgdesc = Clock and world map with extra features for amateur radio (3200x1920 version)
 	url = https://clearskyinstitute.com/ham/HamClock
 	arch = any
@@ -19,9 +19,9 @@ pkgbase = hamclock-huge
 	replaces = hamclock-bigger
 	maintainer = Roy Williams <fang64@gmail.com>
 	repology = project: hamclock-huge
-	source = https://github.com/fang64/hamclock/archive/refs/tags/v4.11.tar.gz
+	source = https://github.com/fang64/hamclock/archive/refs/tags/v4.13.tar.gz
 	source = hamclock.desktop
-	sha256sums = a1f62e092df338ce044173aa62e09a7283687d1cf0173f6bc972af2bcffbff7c
+	sha256sums = d17b34a3b8b1765b84a95e01ab96b0b0e0a4eccc5958e0987e75e919991cc2c7
 	sha256sums = df56e16e9bfab4a6259fd8e9fdffbe8f8d24ff395d2d27434dfd4bfe4adfa85d
 
 pkgname = hamclock-huge

--- a/packages/hamclock-huge/hamclock-huge.pacscript
+++ b/packages/hamclock-huge/hamclock-huge.pacscript
@@ -1,6 +1,6 @@
 pkgname="hamclock-huge"
 arch=("any")
-pkgver="4.11"
+pkgver="4.13"
 source=(
   "https://github.com/fang64/hamclock/archive/refs/tags/v${pkgver}.tar.gz"
   "hamclock.desktop"
@@ -11,7 +11,7 @@ breaks=("hamclock" "hamclock-big" "hamclock-bigger")
 replaces=("hamclock-huge" "${breaks[@]}")
 pkgdesc="Clock and world map with extra features for amateur radio (3200x1920 version)"
 sha256sums=(
-  "a1f62e092df338ce044173aa62e09a7283687d1cf0173f6bc972af2bcffbff7c"
+  "d17b34a3b8b1765b84a95e01ab96b0b0e0a4eccc5958e0987e75e919991cc2c7"
   "df56e16e9bfab4a6259fd8e9fdffbe8f8d24ff395d2d27434dfd4bfe4adfa85d"
 )
 maintainer=("Roy Williams <fang64@gmail.com>")
@@ -20,11 +20,10 @@ repology=("project: ${pkgname}")
 prepare() {
   cd "hamclock-${pkgver}/ESPHamClock"
   # Add -PAC to version for PACSTALL
-  sed -i 's/"/-PAC"/g' version.h
-  sed -i 's/\t-PAC"/\t"/g' version.h
+  sed -i 's/";/-PAC";/g' version.cpp
 
   # Do not check for/install updates
-  sed -i "s/tft.print (F(\"You're up to date\!\"));"'/tft.print(F("Updates disabled for PACSTALL")); tft.setCursor (tft.width()\/8, tft.height()\/3+40); tft.print(F("If this build is outdated by more than a few days,")); tft.setCursor (tft.width()\/8, tft.height()\/3+80); tft.print(F("please email fang64@gmail.com.")); wdDelay(2000);/g' ESPHamClock.ino
+  sed -i "s/tft.print (\"You're up to date\!\");"' \+\/\/[a-z ]*/tft.print("Updates disabled for PACSTALL"); tft.setCursor (tft.width()\/8, tft.height()\/3+40); tft.print("If this build is outdated by more than a few days,"); tft.setCursor (tft.width()\/8, tft.height()\/3+80); tft.print("please email fang64@gmail.com."); wdDelay(2000);/g' ESPHamClock.cpp
   sed -i 's/bool found_newer = false;/return false;bool found_newer;/g' OTAupdate.cpp
 }
 

--- a/packages/hamclock/.SRCINFO
+++ b/packages/hamclock/.SRCINFO
@@ -1,5 +1,5 @@
 pkgbase = hamclock
-	pkgver = 4.11
+	pkgver = 4.13
 	pkgrel = 2
 	pkgdesc = Clock and world map with extra features for amateur radio (800x480 version)
 	url = https://clearskyinstitute.com/ham/HamClock
@@ -20,9 +20,9 @@ pkgbase = hamclock
 	replaces = hamclock-huge
 	maintainer = Roy Williams <fang64@gmail.com>
 	repology = project: hamclock
-	source = https://github.com/fang64/hamclock/archive/refs/tags/v4.11.tar.gz
+	source = https://github.com/fang64/hamclock/archive/refs/tags/v4.13.tar.gz
 	source = hamclock.desktop
-	sha256sums = a1f62e092df338ce044173aa62e09a7283687d1cf0173f6bc972af2bcffbff7c
+	sha256sums = d17b34a3b8b1765b84a95e01ab96b0b0e0a4eccc5958e0987e75e919991cc2c7
 	sha256sums = df56e16e9bfab4a6259fd8e9fdffbe8f8d24ff395d2d27434dfd4bfe4adfa85d
 
 pkgname = hamclock

--- a/packages/hamclock/hamclock.pacscript
+++ b/packages/hamclock/hamclock.pacscript
@@ -1,6 +1,6 @@
 pkgname="hamclock"
 arch=("any")
-pkgver="4.11"
+pkgver="4.13"
 pkgrel="2"
 source=(
   "https://github.com/fang64/hamclock/archive/refs/tags/v${pkgver}.tar.gz"
@@ -12,7 +12,7 @@ breaks=("hamclock-big" "hamclock-bigger" "hamclock-huge")
 replaces=("hamclock" "${breaks[@]}")
 pkgdesc="Clock and world map with extra features for amateur radio (800x480 version)"
 sha256sums=(
-  "a1f62e092df338ce044173aa62e09a7283687d1cf0173f6bc972af2bcffbff7c"
+  "d17b34a3b8b1765b84a95e01ab96b0b0e0a4eccc5958e0987e75e919991cc2c7"
   "df56e16e9bfab4a6259fd8e9fdffbe8f8d24ff395d2d27434dfd4bfe4adfa85d"
 )
 maintainer=("Roy Williams <fang64@gmail.com>")
@@ -21,11 +21,10 @@ repology=("project: ${pkgname}")
 prepare() {
   cd "hamclock-${pkgver}/ESPHamClock"
   # Add -PAC to version for PACSTALL
-  sed -i 's/"/-PAC"/g' version.h
-  sed -i 's/\t-PAC"/\t"/g' version.h
+  sed -i 's/";/-PAC";/g' version.cpp
 
   # Do not check for/install updates
-  sed -i "s/tft.print (F(\"You're up to date\!\"));"'/tft.print(F("Updates disabled for PACSTALL")); tft.setCursor (tft.width()\/8, tft.height()\/3+40); tft.print(F("If this build is outdated by more than a few days,")); tft.setCursor (tft.width()\/8, tft.height()\/3+80); tft.print(F("please email fang64@gmail.com.")); wdDelay(2000);/g' ESPHamClock.ino
+  sed -i "s/tft.print (\"You're up to date\!\");"' \+\/\/[a-z ]*/tft.print("Updates disabled for PACSTALL"); tft.setCursor (tft.width()\/8, tft.height()\/3+40); tft.print("If this build is outdated by more than a few days,"); tft.setCursor (tft.width()\/8, tft.height()\/3+80); tft.print("please email fang64@gmail.com."); wdDelay(2000);/g' ESPHamClock.cpp
   sed -i 's/bool found_newer = false;/return false;bool found_newer;/g' OTAupdate.cpp
 }
 

--- a/srclist
+++ b/srclist
@@ -4378,7 +4378,7 @@ pkgbase = hakuneko-deb
 pkgname = hakuneko-deb
 ---
 pkgbase = hamclock-big
-	pkgver = 4.11
+	pkgver = 4.13
 	pkgrel = 3
 	pkgdesc = Clock and world map with extra features for amateur radio (1600x960 version)
 	url = https://clearskyinstitute.com/ham/HamClock
@@ -4399,15 +4399,15 @@ pkgbase = hamclock-big
 	replaces = hamclock-huge
 	maintainer = Roy Williams <fang64@gmail.com>
 	repology = project: hamclock-big
-	source = https://github.com/fang64/hamclock/archive/refs/tags/v4.11.tar.gz
+	source = https://github.com/fang64/hamclock/archive/refs/tags/v4.13.tar.gz
 	source = hamclock.desktop
-	sha256sums = a1f62e092df338ce044173aa62e09a7283687d1cf0173f6bc972af2bcffbff7c
+	sha256sums = d17b34a3b8b1765b84a95e01ab96b0b0e0a4eccc5958e0987e75e919991cc2c7
 	sha256sums = df56e16e9bfab4a6259fd8e9fdffbe8f8d24ff395d2d27434dfd4bfe4adfa85d
 
 pkgname = hamclock-big
 ---
 pkgbase = hamclock-bigger
-	pkgver = 4.11
+	pkgver = 4.13
 	pkgdesc = Clock and world map with extra features for amateur radio (2400x1440 version)
 	url = https://clearskyinstitute.com/ham/HamClock
 	arch = any
@@ -4427,15 +4427,15 @@ pkgbase = hamclock-bigger
 	replaces = hamclock-huge
 	maintainer = Roy Williams <fang64@gmail.com>
 	repology = project: hamclock-bigger
-	source = https://github.com/fang64/hamclock/archive/refs/tags/v4.11.tar.gz
+	source = https://github.com/fang64/hamclock/archive/refs/tags/v4.13.tar.gz
 	source = hamclock.desktop
-	sha256sums = a1f62e092df338ce044173aa62e09a7283687d1cf0173f6bc972af2bcffbff7c
+	sha256sums = d17b34a3b8b1765b84a95e01ab96b0b0e0a4eccc5958e0987e75e919991cc2c7
 	sha256sums = df56e16e9bfab4a6259fd8e9fdffbe8f8d24ff395d2d27434dfd4bfe4adfa85d
 
 pkgname = hamclock-bigger
 ---
 pkgbase = hamclock-huge
-	pkgver = 4.11
+	pkgver = 4.13
 	pkgdesc = Clock and world map with extra features for amateur radio (3200x1920 version)
 	url = https://clearskyinstitute.com/ham/HamClock
 	arch = any
@@ -4455,15 +4455,15 @@ pkgbase = hamclock-huge
 	replaces = hamclock-bigger
 	maintainer = Roy Williams <fang64@gmail.com>
 	repology = project: hamclock-huge
-	source = https://github.com/fang64/hamclock/archive/refs/tags/v4.11.tar.gz
+	source = https://github.com/fang64/hamclock/archive/refs/tags/v4.13.tar.gz
 	source = hamclock.desktop
-	sha256sums = a1f62e092df338ce044173aa62e09a7283687d1cf0173f6bc972af2bcffbff7c
+	sha256sums = d17b34a3b8b1765b84a95e01ab96b0b0e0a4eccc5958e0987e75e919991cc2c7
 	sha256sums = df56e16e9bfab4a6259fd8e9fdffbe8f8d24ff395d2d27434dfd4bfe4adfa85d
 
 pkgname = hamclock-huge
 ---
 pkgbase = hamclock
-	pkgver = 4.11
+	pkgver = 4.13
 	pkgrel = 2
 	pkgdesc = Clock and world map with extra features for amateur radio (800x480 version)
 	url = https://clearskyinstitute.com/ham/HamClock
@@ -4484,9 +4484,9 @@ pkgbase = hamclock
 	replaces = hamclock-huge
 	maintainer = Roy Williams <fang64@gmail.com>
 	repology = project: hamclock
-	source = https://github.com/fang64/hamclock/archive/refs/tags/v4.11.tar.gz
+	source = https://github.com/fang64/hamclock/archive/refs/tags/v4.13.tar.gz
 	source = hamclock.desktop
-	sha256sums = a1f62e092df338ce044173aa62e09a7283687d1cf0173f6bc972af2bcffbff7c
+	sha256sums = d17b34a3b8b1765b84a95e01ab96b0b0e0a4eccc5958e0987e75e919991cc2c7
 	sha256sums = df56e16e9bfab4a6259fd8e9fdffbe8f8d24ff395d2d27434dfd4bfe4adfa85d
 
 pkgname = hamclock


### PR DESCRIPTION
Update hamclock to 4.13
Update pacscripts for hamclock code restructure so disabled update message and PAC version suffix continue to display.