### PR TITLE
add: `lm-studio-app`

### DIFF
--- a/packagelist
+++ b/packagelist
@@ -333,6 +333,7 @@ linux-modules-lts-6.6-deb
 linux-modules-stable-deb
 linux-wifi-hotspot-deb
 lix-git
+lm-studio-app
 lrz-syncshare-deb
 lsd-deb
 lunacy-deb

--- a/packages/lm-studio-app/.SRCINFO
+++ b/packages/lm-studio-app/.SRCINFO
@@ -4,6 +4,7 @@ pkgbase = lm-studio-app
 	pkgdesc = Experiment with LLMs on your computer.
 	url = https://lmstudio.ai
 	arch = amd64
+	makedepends = imagemagick
 	replaces = lm-studio
 	maintainer = chrisb09 <christian.brinkmann09@gmail.com>
 	source = https://installers.lmstudio.ai/linux/x64/0.3.13-2/LM-Studio-0.3.13-2-x64.AppImage

--- a/packages/lm-studio-app/.SRCINFO
+++ b/packages/lm-studio-app/.SRCINFO
@@ -7,8 +7,6 @@ pkgbase = lm-studio-app
 	replaces = lm-studio
 	maintainer = chrisb09 <christian.brinkmann09@gmail.com>
 	source = https://installers.lmstudio.ai/linux/x64/0.3.13-2/LM-Studio-0.3.13-2-x64.AppImage
-	source = https://lmstudio.ai/_next/static/media/android-chrome-192x192.3a60873f.png
 	sha256sums = 5a05217e4f0588e22e6aa9c4d61d3eacdc4f11023179d17e0f48357ec3294908
-	sha256sums = f0a738b118a2b80fbcbd010968ca86ba81cc175c8654e62994e85d19dd08235e
 
 pkgname = lm-studio-app

--- a/packages/lm-studio-app/.SRCINFO
+++ b/packages/lm-studio-app/.SRCINFO
@@ -1,0 +1,14 @@
+pkgbase = lm-studio-app
+	gives = lm-studio
+	pkgver = 0.3.13-2
+	pkgdesc = Experiment with LLMs on your computer.
+	url = https://lmstudio.ai
+	arch = amd64
+	replaces = lm-studio
+	maintainer = chrisb09 <christian.brinkmann09@gmail.com>
+	source = https://installers.lmstudio.ai/linux/x64/0.3.13-2/LM-Studio-0.3.13-2-x64.AppImage
+	source = https://lmstudio.ai/_next/static/media/android-chrome-192x192.3a60873f.png
+	sha256sums = 5a05217e4f0588e22e6aa9c4d61d3eacdc4f11023179d17e0f48357ec3294908
+	sha256sums = f0a738b118a2b80fbcbd010968ca86ba81cc175c8654e62994e85d19dd08235e
+
+pkgname = lm-studio-app

--- a/packages/lm-studio-app/lm-studio-app.pacscript
+++ b/packages/lm-studio-app/lm-studio-app.pacscript
@@ -5,9 +5,10 @@ pkgdesc="Experiment with LLMs on your computer."
 url='https://lmstudio.ai'
 arch=('amd64')
 replaces=("${gives}")
+_icon_name="android-chrome-192x192.3a60873f.png"
 source=(
   "https://installers.lmstudio.ai/linux/x64/${pkgver}/LM-Studio-${pkgver}-x64.AppImage"
-  "https://lmstudio.ai/_next/static/media/android-chrome-192x192.3a60873f.png"
+  "https://lmstudio.ai/_next/static/media/${_icon_name}"
 )
 appimage="LM-Studio-${pkgver}-x64.AppImage"
 sha256sums=(
@@ -19,15 +20,38 @@ maintainer=("chrisb09 <christian.brinkmann09@gmail.com>")
 package() {
   cd "${srcdir}"
 
+  # Make the AppImage executable
   chmod +x "${appimage}"
+
+  # Extract the .desktop and .png files from the AppImage
   ./"${appimage}" --appimage-extract "${gives}.desktop" &> /dev/null
   ./"${appimage}" --appimage-extract "${gives}.png" &> /dev/null
 
+  # Install the AppImage to the /usr/bin directory
   install -Dm755 "${appimage}" "${pkgdir}/usr/bin/${gives}"
+
+  # Install the .desktop file to the applications directory
   install -Dm644 "squashfs-root/${gives}.desktop" -t "${pkgdir}/usr/share/applications"
 
+  # Modify the .desktop file to use the correct executable path
   sed -i "s|Exec=AppRun|Exec=APPIMAGELAUNCHER_DISABLE=1 /usr/bin/${gives}|g" "${pkgdir}/usr/share/applications/${gives}.desktop"
 
-  mv "android-chrome-192x192.3a60873f.png" "${gives}.png"
-  install -Dm644 "${gives}.png" -t "${pkgdir}/usr/share/icons/hicolor/192x192/apps"
+  # Check if the icon file is available locally
+  if [[ -f ${_icon_name} ]]; then
+    mv "${_icon_name}" "${gives}.png"
+    # Install the icon to the icons directory
+    install -Dm644 "${gives}.png" -t "${pkgdir}/usr/share/icons/hicolor/192x192/apps"
+  else
+    # If the icon is not available locally, try to download it from the website
+    if [[ -n $(curl -s "https://lmstudio.ai/") ]]; then
+      icon_url=$(curl -s "https://lmstudio.ai/" | grep -oP '<link\srel="icon"\shref="\K[^"]+' | sed 's|^|https://lmstudio.ai|')
+      echo "Icon not found, downloading from \"${icon_url}\""
+      curl -s -o "${gives}.png" "${icon_url}"
+      # Install the downloaded icon to the icons directory
+      install -Dm644 "${gives}.png" -t "${pkgdir}/usr/share/icons/hicolor/192x192/apps"
+    else
+      # If the website is not reachable, print an error message
+      echo "Could not reach lmstudio.ai, skipping icon download. This is likely due to the sandbox in pacstall. If you want to download and install the icon as well, disable the sandbox by adding -Ns to the command."
+    fi
+  fi
 }

--- a/packages/lm-studio-app/lm-studio-app.pacscript
+++ b/packages/lm-studio-app/lm-studio-app.pacscript
@@ -5,15 +5,12 @@ pkgdesc="Experiment with LLMs on your computer."
 url='https://lmstudio.ai'
 arch=('amd64')
 replaces=("${gives}")
-_icon_name="android-chrome-192x192.3a60873f.png"
 source=(
   "https://installers.lmstudio.ai/linux/x64/${pkgver}/LM-Studio-${pkgver}-x64.AppImage"
-  "https://lmstudio.ai/_next/static/media/${_icon_name}"
 )
 appimage="LM-Studio-${pkgver}-x64.AppImage"
 sha256sums=(
   "5a05217e4f0588e22e6aa9c4d61d3eacdc4f11023179d17e0f48357ec3294908"
-  "f0a738b118a2b80fbcbd010968ca86ba81cc175c8654e62994e85d19dd08235e"
 )
 maintainer=("chrisb09 <christian.brinkmann09@gmail.com>")
 
@@ -25,7 +22,6 @@ package() {
 
   # Extract the .desktop and .png files from the AppImage
   ./"${appimage}" --appimage-extract "${gives}.desktop" &> /dev/null
-  ./"${appimage}" --appimage-extract "${gives}.png" &> /dev/null
 
   # Install the AppImage to the /usr/bin directory
   install -Dm755 "${appimage}" "${pkgdir}/usr/bin/${gives}"
@@ -36,22 +32,34 @@ package() {
   # Modify the .desktop file to use the correct executable path
   sed -i "s|Exec=AppRun|Exec=APPIMAGELAUNCHER_DISABLE=1 /usr/bin/${gives}|g" "${pkgdir}/usr/share/applications/${gives}.desktop"
 
-  # Check if the icon file is available locally
-  if [[ -f ${_icon_name} ]]; then
-    mv "${_icon_name}" "${gives}.png"
-    # Install the icon to the icons directory
-    install -Dm644 "${gives}.png" -t "${pkgdir}/usr/share/icons/hicolor/192x192/apps"
+  icon_extension=".png"
+  ./"${appimage}" --appimage-extract "${gives}${icon_extension}" &> /dev/null
+  # ${gives}.png is likely a symlink, so we need to get the actual file
+  if [[ -L "squashfs-root/${gives}${icon_extension}" ]]; then
+    actual_icon=$(readlink "squashfs-root/${gives}${icon_extension}")
+    ./"${appimage}" --appimage-extract "${actual_icon}" &> /dev/null
+    install -Dm644 "squashfs-root/${actual_icon}" -t "${pkgdir}/usr/share/icons/hicolor/0x0/apps"
   else
-    # If the icon is not available locally, try to download it from the website
-    if [[ -n $(curl -s "https://lmstudio.ai/") ]]; then
-      icon_url=$(curl -s "https://lmstudio.ai/" | grep -oP '<link\srel="icon"\shref="\K[^"]+' | sed 's|^|https://lmstudio.ai|')
-      echo "Icon not found, downloading from \"${icon_url}\""
-      curl -s -o "${gives}.png" "${icon_url}"
-      # Install the downloaded icon to the icons directory
-      install -Dm644 "${gives}.png" -t "${pkgdir}/usr/share/icons/hicolor/192x192/apps"
-    else
-      # If the website is not reachable, print an error message
-      echo "Could not reach lmstudio.ai, skipping icon download. This is likely due to the sandbox in pacstall. If you want to download and install the icon as well, disable the sandbox by adding -Ns to the command."
-    fi
+    install -Dm644 "squashfs-root/${gives}${icon_extension}" -t "${pkgdir}/usr/share/icons/hicolor/0x0/apps"
+  fi
+
+  src_icon="${pkgdir}/usr/share/icons/hicolor/0x0/apps/${gives}${icon_extension}"
+  sizes=("16x16" "32x32" "48x48" "64x64" "128x128" "256x256")
+
+  # check if gm convert or imagemagick is installed
+  if command -v gm &> /dev/null; then
+    # Loop through each size and create resized icons
+    for size in "${sizes[@]}"; do
+      install -dm755 "${pkgdir}/usr/share/icons/hicolor/${size}/apps"
+      gm convert "${src_icon}" -resize "${size}" "${pkgdir}/usr/share/icons/hicolor/${size}/apps/${gives}${icon_extension}"
+    done
+  elif command -v convert &> /dev/null; then
+    # Loop through each size and create resized icons
+    for size in "${sizes[@]}"; do
+      install -dm755 "${pkgdir}/usr/share/icons/hicolor/${size}/apps"
+      convert "${src_icon}" -resize "${size}" "${pkgdir}/usr/share/icons/hicolor/${size}/apps/${gives}${icon_extension}"
+    done
+  else
+    echo "Neither gm nor convert is installed. Please install one of them to resize the icon."
   fi
 }

--- a/packages/lm-studio-app/lm-studio-app.pacscript
+++ b/packages/lm-studio-app/lm-studio-app.pacscript
@@ -1,0 +1,33 @@
+pkgname="lm-studio-app"
+gives="lm-studio"
+pkgver="0.3.13-2"
+pkgdesc="Experiment with LLMs on your computer."
+url='https://lmstudio.ai'
+arch=('amd64')
+replaces=("${gives}")
+source=(
+  "https://installers.lmstudio.ai/linux/x64/${pkgver}/LM-Studio-${pkgver}-x64.AppImage"
+  "https://lmstudio.ai/_next/static/media/android-chrome-192x192.3a60873f.png"
+)
+appimage="LM-Studio-${pkgver}-x64.AppImage"
+sha256sums=(
+  "5a05217e4f0588e22e6aa9c4d61d3eacdc4f11023179d17e0f48357ec3294908"
+  "f0a738b118a2b80fbcbd010968ca86ba81cc175c8654e62994e85d19dd08235e"
+)
+maintainer=("chrisb09 <christian.brinkmann09@gmail.com>")
+
+package() {
+  cd "${srcdir}"
+
+  chmod +x "${appimage}"
+  ./"${appimage}" --appimage-extract "${gives}.desktop" &> /dev/null
+  ./"${appimage}" --appimage-extract "${gives}.png" &> /dev/null
+
+  install -Dm755 "${appimage}" "${pkgdir}/usr/bin/${gives}"
+  install -Dm644 "squashfs-root/${gives}.desktop" -t "${pkgdir}/usr/share/applications"
+
+  sed -i "s|Exec=AppRun|Exec=APPIMAGELAUNCHER_DISABLE=1 /usr/bin/${gives}|g" "${pkgdir}/usr/share/applications/${gives}.desktop"
+
+  mv "android-chrome-192x192.3a60873f.png" "${gives}.png"
+  install -Dm644 "${gives}.png" -t "${pkgdir}/usr/share/icons/hicolor/192x192/apps"
+}

--- a/packages/lm-studio-app/lm-studio-app.pacscript
+++ b/packages/lm-studio-app/lm-studio-app.pacscript
@@ -5,6 +5,7 @@ pkgdesc="Experiment with LLMs on your computer."
 url='https://lmstudio.ai'
 arch=('amd64')
 replaces=("${gives}")
+makedepends=("imagemagick")
 source=(
   "https://installers.lmstudio.ai/linux/x64/${pkgver}/LM-Studio-${pkgver}-x64.AppImage"
 )
@@ -32,34 +33,22 @@ package() {
   # Modify the .desktop file to use the correct executable path
   sed -i "s|Exec=AppRun|Exec=APPIMAGELAUNCHER_DISABLE=1 /usr/bin/${gives}|g" "${pkgdir}/usr/share/applications/${gives}.desktop"
 
-  icon_extension=".png"
-  ./"${appimage}" --appimage-extract "${gives}${icon_extension}" &> /dev/null
+  ./"${appimage}" --appimage-extract "lm-studio.png" &> /dev/null
   # ${gives}.png is likely a symlink, so we need to get the actual file
-  if [[ -L "squashfs-root/${gives}${icon_extension}" ]]; then
-    actual_icon=$(readlink "squashfs-root/${gives}${icon_extension}")
+  if [[ -L "squashfs-root/lm-studio.png" ]]; then
+    actual_icon=$(readlink "squashfs-root/lm-studio.png")
     ./"${appimage}" --appimage-extract "${actual_icon}" &> /dev/null
     install -Dm644 "squashfs-root/${actual_icon}" -t "${pkgdir}/usr/share/icons/hicolor/0x0/apps"
-  else
-    install -Dm644 "squashfs-root/${gives}${icon_extension}" -t "${pkgdir}/usr/share/icons/hicolor/0x0/apps"
+  else # If it's not a symlink, just install it
+    install -Dm644 "squashfs-root/lm-studio.png" -t "${pkgdir}/usr/share/icons/hicolor/0x0/apps"
   fi
 
-  src_icon="${pkgdir}/usr/share/icons/hicolor/0x0/apps/${gives}${icon_extension}"
+  src_icon="${pkgdir}/usr/share/icons/hicolor/0x0/apps/lm-studio.png"
   sizes=("16x16" "32x32" "48x48" "64x64" "128x128" "256x256")
 
-  # check if gm convert or imagemagick is installed
-  if command -v gm &> /dev/null; then
-    # Loop through each size and create resized icons
-    for size in "${sizes[@]}"; do
-      install -dm755 "${pkgdir}/usr/share/icons/hicolor/${size}/apps"
-      gm convert "${src_icon}" -resize "${size}" "${pkgdir}/usr/share/icons/hicolor/${size}/apps/${gives}${icon_extension}"
-    done
-  elif command -v convert &> /dev/null; then
-    # Loop through each size and create resized icons
-    for size in "${sizes[@]}"; do
-      install -dm755 "${pkgdir}/usr/share/icons/hicolor/${size}/apps"
-      convert "${src_icon}" -resize "${size}" "${pkgdir}/usr/share/icons/hicolor/${size}/apps/${gives}${icon_extension}"
-    done
-  else
-    echo "Neither gm nor convert is installed. Please install one of them to resize the icon."
-  fi
+  # Loop through each size and create resized icons
+  for size in "${sizes[@]}"; do
+    install -dm755 "${pkgdir}/usr/share/icons/hicolor/${size}/apps"
+    convert "${src_icon}" -resize "${size}" "${pkgdir}/usr/share/icons/hicolor/${size}/apps/lm-studio.png"
+  done
 }

--- a/srclist
+++ b/srclist
@@ -6727,9 +6727,7 @@ pkgbase = lm-studio-app
 	replaces = lm-studio
 	maintainer = chrisb09 <christian.brinkmann09@gmail.com>
 	source = https://installers.lmstudio.ai/linux/x64/0.3.13-2/LM-Studio-0.3.13-2-x64.AppImage
-	source = https://lmstudio.ai/_next/static/media/android-chrome-192x192.3a60873f.png
 	sha256sums = 5a05217e4f0588e22e6aa9c4d61d3eacdc4f11023179d17e0f48357ec3294908
-	sha256sums = f0a738b118a2b80fbcbd010968ca86ba81cc175c8654e62994e85d19dd08235e
 
 pkgname = lm-studio-app
 ---

--- a/srclist
+++ b/srclist
@@ -6718,6 +6718,21 @@ pkgbase = lix-git
 
 pkgname = lix-git
 ---
+pkgbase = lm-studio-app
+	gives = lm-studio
+	pkgver = 0.3.13-2
+	pkgdesc = Experiment with LLMs on your computer.
+	url = https://lmstudio.ai
+	arch = amd64
+	replaces = lm-studio
+	maintainer = chrisb09 <christian.brinkmann09@gmail.com>
+	source = https://installers.lmstudio.ai/linux/x64/0.3.13-2/LM-Studio-0.3.13-2-x64.AppImage
+	source = https://lmstudio.ai/_next/static/media/android-chrome-192x192.3a60873f.png
+	sha256sums = 5a05217e4f0588e22e6aa9c4d61d3eacdc4f11023179d17e0f48357ec3294908
+	sha256sums = f0a738b118a2b80fbcbd010968ca86ba81cc175c8654e62994e85d19dd08235e
+
+pkgname = lm-studio-app
+---
 pkgbase = lrz-syncshare-deb
 	gives = lrz-sync-share
 	pkgver = 16.3.100

--- a/srclist
+++ b/srclist
@@ -6724,6 +6724,7 @@ pkgbase = lm-studio-app
 	pkgdesc = Experiment with LLMs on your computer.
 	url = https://lmstudio.ai
 	arch = amd64
+	makedepends = imagemagick
 	replaces = lm-studio
 	maintainer = chrisb09 <christian.brinkmann09@gmail.com>
 	source = https://installers.lmstudio.ai/linux/x64/0.3.13-2/LM-Studio-0.3.13-2-x64.AppImage


### PR DESCRIPTION
Adds lm-studio for x86 (I presume they meant x86_64) via the official AppImage. Tested successfully on an x86_64 CPU.

Since the AppImage does not include a working Icon, this script currently also retrieves the website's favicon and installs it to the appropriate location.