### PR TITLE
add: `tuckr-git`

### DIFF
--- a/packagelist
+++ b/packagelist
@@ -699,6 +699,7 @@ tre-git
 treefetch-bin
 truckersmp-cli
 ttf-fira-sans
+tuckr-git
 tutanota-app
 typora-deb
 u-boot-mobian-deb

--- a/packages/tuckr-git/.SRCINFO
+++ b/packages/tuckr-git/.SRCINFO
@@ -1,5 +1,5 @@
 pkgbase = tuckr-git
-	pkgver = 0.11.1
+	pkgver = 0.11.0
 	pkgrel = 1
 	epoch = 1
 	pkgdesc = A super powered replacement for GNU Stow
@@ -12,7 +12,7 @@ pkgbase = tuckr-git
 	license = GPL-3.0
 	maintainer = Bahar KURT <kurtbahartr@gmail.com>
 	repology = project: tuckr
-	source = git+https://github.com/RaphGL/Tuckr#tag=0.11.1
+	source = git+https://github.com/RaphGL/Tuckr#tag=0.11.0
 	sha256sums = SKIP
 
 pkgname = tuckr-git

--- a/packages/tuckr-git/.SRCINFO
+++ b/packages/tuckr-git/.SRCINFO
@@ -1,0 +1,18 @@
+pkgbase = tuckr-git
+	pkgver = 0.11.1
+	pkgrel = 1
+	epoch = 1
+	pkgdesc = A super powered replacement for GNU Stow
+	url = https://github.com/RaphGL/Tuckr
+	arch = amd64
+	arch = i386
+	arch = arm64
+	makedepends = cargo
+	makedepends = git
+	license = GPL-3.0
+	maintainer = Bahar KURT <kurtbahartr@gmail.com>
+	repology = project: tuckr
+	source = git+https://github.com/RaphGL/Tuckr#tag=0.11.1
+	sha256sums = SKIP
+
+pkgname = tuckr-git

--- a/packages/tuckr-git/tuckr-git.pacscript
+++ b/packages/tuckr-git/tuckr-git.pacscript
@@ -1,0 +1,25 @@
+pkgname=tuckr-git
+pkgver=0.11.1
+pkgrel=1
+epoch=1
+pkgdesc="A super powered replacement for GNU Stow"
+arch=('amd64' 'i386' 'arm64')
+url="https://github.com/RaphGL/Tuckr"
+license=('GPL-3.0')
+makedepends=('cargo' 'git')
+source=("git+${url}#tag=${pkgver}")
+sha256sums=("SKIP")
+repology=("project: tuckr")
+maintainer=("Bahar KURT <kurtbahartr@gmail.com>")
+
+build() {
+  export RUSTUP_TOOLCHAIN=stable
+  export CARGO_TARGET_DIR=target
+  cd Tuckr
+  cargo build --release
+}
+
+package() {
+  cd Tuckr
+  install -Dm0755 -t "${pkgdir}/usr/bin/" "target/release/tuckr"
+}

--- a/packages/tuckr-git/tuckr-git.pacscript
+++ b/packages/tuckr-git/tuckr-git.pacscript
@@ -13,13 +13,6 @@ repology=("project: tuckr")
 maintainer=("Bahar KURT <kurtbahartr@gmail.com>")
 external_connection=true
 
-prepare() {
-  cd Tuckr
-  echo 'cargo-features = ["edition2024"]' > Cargo.toml.tmp
-  cat Cargo.toml >> Cargo.toml.tmp
-  mv Cargo.toml.tmp Cargo.toml
-}
-
 build() {
   export RUSTUP_TOOLCHAIN=stable
   export CARGO_TARGET_DIR=target

--- a/packages/tuckr-git/tuckr-git.pacscript
+++ b/packages/tuckr-git/tuckr-git.pacscript
@@ -11,6 +11,14 @@ source=("git+${url}#tag=${pkgver}")
 sha256sums=("SKIP")
 repology=("project: tuckr")
 maintainer=("Bahar KURT <kurtbahartr@gmail.com>")
+external_connection=true
+
+prepare() {
+  cd Tuckr
+  echo 'cargo-features = ["edition2024"]' > Cargo.toml.tmp
+  cat Cargo.toml >> Cargo.toml.tmp
+  mv Cargo.toml.tmp Cargo.toml
+}
 
 build() {
   export RUSTUP_TOOLCHAIN=stable

--- a/packages/tuckr-git/tuckr-git.pacscript
+++ b/packages/tuckr-git/tuckr-git.pacscript
@@ -1,5 +1,5 @@
 pkgname=tuckr-git
-pkgver=0.11.1
+pkgver=0.11.0
 pkgrel=1
 epoch=1
 pkgdesc="A super powered replacement for GNU Stow"

--- a/srclist
+++ b/srclist
@@ -13290,7 +13290,7 @@ pkgbase = ttf-fira-sans
 pkgname = ttf-fira-sans
 ---
 pkgbase = tuckr-git
-	pkgver = 0.11.1
+	pkgver = 0.11.0
 	pkgrel = 1
 	epoch = 1
 	pkgdesc = A super powered replacement for GNU Stow
@@ -13303,7 +13303,7 @@ pkgbase = tuckr-git
 	license = GPL-3.0
 	maintainer = Bahar KURT <kurtbahartr@gmail.com>
 	repology = project: tuckr
-	source = git+https://github.com/RaphGL/Tuckr#tag=0.11.1
+	source = git+https://github.com/RaphGL/Tuckr#tag=0.11.0
 	sha256sums = SKIP
 
 pkgname = tuckr-git

--- a/srclist
+++ b/srclist
@@ -13289,6 +13289,25 @@ pkgbase = ttf-fira-sans
 
 pkgname = ttf-fira-sans
 ---
+pkgbase = tuckr-git
+	pkgver = 0.11.1
+	pkgrel = 1
+	epoch = 1
+	pkgdesc = A super powered replacement for GNU Stow
+	url = https://github.com/RaphGL/Tuckr
+	arch = amd64
+	arch = i386
+	arch = arm64
+	makedepends = cargo
+	makedepends = git
+	license = GPL-3.0
+	maintainer = Bahar KURT <kurtbahartr@gmail.com>
+	repology = project: tuckr
+	source = git+https://github.com/RaphGL/Tuckr#tag=0.11.1
+	sha256sums = SKIP
+
+pkgname = tuckr-git
+---
 pkgbase = tutanota-app
 	gives = tutanota
 	pkgver = 218.240227.0


### PR DESCRIPTION
`cargo` builddep doesn't install during installation and has to be installed manually. See: https://github.com/pacstall/pacstall/issues/1352