### PR TITLE
upd(insomnia-deb): `2023.4.0` -> `11.1.0`

### DIFF
--- a/packages/insomnia-deb/.SRCINFO
+++ b/packages/insomnia-deb/.SRCINFO
@@ -1,11 +1,11 @@
 pkgbase = insomnia-deb
 	gives = insomnia
-	pkgver = 2023.4.0
+	pkgver = 11.1.0
 	pkgdesc = The open-source, cross-platform API client for GraphQL, REST, WebSockets and gRPC
 	url = https://github.com/Kong/insomnia/
 	arch = amd64
 	maintainer = Diegiwg <diegiwg@gmail.com>
-	source = https://github.com/Kong/insomnia/releases/download/core%402023.4.0/Insomnia.Core-2023.4.0.deb
-	sha256sums = eed91dd07689783742bd7d6dd57087aeb436df116b70cb32d67849244a7a9259
+	source = https://github.com/Kong/insomnia/releases/download/core%4011.1.0/Insomnia.Core-11.1.0.deb
+	sha256sums = e0797a3707ca729fd326de6914485b28713ada7430bed76ec2cae421471a7418
 
 pkgname = insomnia-deb

--- a/packages/insomnia-deb/insomnia-deb.pacscript
+++ b/packages/insomnia-deb/insomnia-deb.pacscript
@@ -1,9 +1,9 @@
 pkgname="insomnia-deb"
 gives="insomnia"
-pkgver="2023.4.0"
+pkgver="11.1.0"
 arch=("amd64")
 source=("https://github.com/Kong/insomnia/releases/download/core%40${pkgver}/Insomnia.Core-${pkgver}.deb")
-sha256sums=("eed91dd07689783742bd7d6dd57087aeb436df116b70cb32d67849244a7a9259")
+sha256sums=("e0797a3707ca729fd326de6914485b28713ada7430bed76ec2cae421471a7418")
 url="https://github.com/Kong/insomnia/"
 pkgdesc="The open-source, cross-platform API client for GraphQL, REST, WebSockets and gRPC"
 maintainer=("Diegiwg <diegiwg@gmail.com>")

--- a/srclist
+++ b/srclist
@@ -5259,13 +5259,13 @@ pkgname = imwheel-exclude-patched-git
 ---
 pkgbase = insomnia-deb
 	gives = insomnia
-	pkgver = 2023.4.0
+	pkgver = 11.1.0
 	pkgdesc = The open-source, cross-platform API client for GraphQL, REST, WebSockets and gRPC
 	url = https://github.com/Kong/insomnia/
 	arch = amd64
 	maintainer = Diegiwg <diegiwg@gmail.com>
-	source = https://github.com/Kong/insomnia/releases/download/core%402023.4.0/Insomnia.Core-2023.4.0.deb
-	sha256sums = eed91dd07689783742bd7d6dd57087aeb436df116b70cb32d67849244a7a9259
+	source = https://github.com/Kong/insomnia/releases/download/core%4011.1.0/Insomnia.Core-11.1.0.deb
+	sha256sums = e0797a3707ca729fd326de6914485b28713ada7430bed76ec2cae421471a7418
 
 pkgname = insomnia-deb
 ---


### PR DESCRIPTION
It seems that starting with some version `8.*` - or `2023.*` - a versioning change was done. That unfortunately means that apt will reject updating an existing installation - although in my case running the installation cmd twice did work, so I'm assuming it did uninstall the old package before complaining about the version downgrade (after all, 11 << 2023).

I'm not aware of a pacscript definition that would tell apt to ignore versioning...