### PR TITLE
upd(vscodium-deb): `1.99.32846` -> `1.101.03933`

### DIFF
--- a/packages/vscodium-deb/.SRCINFO
+++ b/packages/vscodium-deb/.SRCINFO
@@ -1,6 +1,6 @@
 pkgbase = vscodium-deb
 	gives = codium
-	pkgver = 1.99.32846
+	pkgver = 1.101.03933
 	pkgdesc = Binary releases of VS Code without MS branding/telemetry/licensing
 	arch = arm64
 	arch = amd64
@@ -8,9 +8,9 @@ pkgbase = vscodium-deb
 	maintainer = Oren Klopfer <oren@taumoda.com>
 	maintainer = James Ed Randson <jimedrand@disroot.org>
 	repology = project: vscodium
-	source_arm64 = https://github.com/VSCodium/vscodium/releases/download/1.99.32846/codium_1.99.32846_arm64.deb
-	sha256sums_arm64 = a0d134be31b9d13fa8d0eacd2b41b12068444ea2de6807606a10518ee14cee2c
-	source_amd64 = https://github.com/VSCodium/vscodium/releases/download/1.99.32846/codium_1.99.32846_amd64.deb
-	sha256sums_amd64 = dd6b6b81f24bddc52de2ffc32ba6a96bd10aeeca5992f3fbe8295f08c8e6d3cd
+	source_arm64 = https://github.com/VSCodium/vscodium/releases/download/1.101.03933/codium_1.101.03933_arm64.deb
+	sha256sums_arm64 = aa665651d723d472cba6a32555701c888fc3133559efe8e827ed0cd6db175a9e
+	source_amd64 = https://github.com/VSCodium/vscodium/releases/download/1.101.03933/codium_1.101.03933_amd64.deb
+	sha256sums_amd64 = a3af979e6dd02d2bc31a95ba69d4e9715b801c94dd285d93c94cb3d1f2c16071
 
 pkgname = vscodium-deb

--- a/packages/vscodium-deb/vscodium-deb.pacscript
+++ b/packages/vscodium-deb/vscodium-deb.pacscript
@@ -1,12 +1,12 @@
 pkgname="vscodium-deb"
 gives="codium"
 breaks=("${gives}")
-pkgver="1.99.32846"
+pkgver="1.101.03933"
 arch=("arm64" "amd64")
 repology=("project: vscodium")
 maintainer=("Oren Klopfer <oren@taumoda.com>" "James Ed Randson <jimedrand@disroot.org>")
 pkgdesc="Binary releases of VS Code without MS branding/telemetry/licensing"
 source_arm64=("https://github.com/VSCodium/vscodium/releases/download/${pkgver}/${gives}_${pkgver}_arm64.deb")
 source_amd64=("https://github.com/VSCodium/vscodium/releases/download/${pkgver}/${gives}_${pkgver}_amd64.deb")
-sha256sums_arm64=("a0d134be31b9d13fa8d0eacd2b41b12068444ea2de6807606a10518ee14cee2c")
-sha256sums_amd64=("dd6b6b81f24bddc52de2ffc32ba6a96bd10aeeca5992f3fbe8295f08c8e6d3cd")
+sha256sums_arm64=("aa665651d723d472cba6a32555701c888fc3133559efe8e827ed0cd6db175a9e")
+sha256sums_amd64=("a3af979e6dd02d2bc31a95ba69d4e9715b801c94dd285d93c94cb3d1f2c16071")

--- a/srclist
+++ b/srclist
@@ -14457,7 +14457,7 @@ pkgname = vscodium-bin
 ---
 pkgbase = vscodium-deb
 	gives = codium
-	pkgver = 1.99.32846
+	pkgver = 1.101.03933
 	pkgdesc = Binary releases of VS Code without MS branding/telemetry/licensing
 	arch = arm64
 	arch = amd64
@@ -14465,10 +14465,10 @@ pkgbase = vscodium-deb
 	maintainer = Oren Klopfer <oren@taumoda.com>
 	maintainer = James Ed Randson <jimedrand@disroot.org>
 	repology = project: vscodium
-	source_arm64 = https://github.com/VSCodium/vscodium/releases/download/1.99.32846/codium_1.99.32846_arm64.deb
-	sha256sums_arm64 = a0d134be31b9d13fa8d0eacd2b41b12068444ea2de6807606a10518ee14cee2c
-	source_amd64 = https://github.com/VSCodium/vscodium/releases/download/1.99.32846/codium_1.99.32846_amd64.deb
-	sha256sums_amd64 = dd6b6b81f24bddc52de2ffc32ba6a96bd10aeeca5992f3fbe8295f08c8e6d3cd
+	source_arm64 = https://github.com/VSCodium/vscodium/releases/download/1.101.03933/codium_1.101.03933_arm64.deb
+	sha256sums_arm64 = aa665651d723d472cba6a32555701c888fc3133559efe8e827ed0cd6db175a9e
+	source_amd64 = https://github.com/VSCodium/vscodium/releases/download/1.101.03933/codium_1.101.03933_amd64.deb
+	sha256sums_amd64 = a3af979e6dd02d2bc31a95ba69d4e9715b801c94dd285d93c94cb3d1f2c16071
 
 pkgname = vscodium-deb
 ---


### PR DESCRIPTION
As v1.99 is quite a few months old I took the liberty to update the package.