### PR TITLE
rm: `libndi4`, `obs-ndi`

### DIFF
--- a/packagelist
+++ b/packagelist
@@ -315,7 +315,6 @@ libhyprgraphics-bin
 libhyprutils-bin
 libicu-deb
 liblcf
-libndi4-deb
 libresprite-git
 libressl
 librewolf-app
@@ -498,7 +497,6 @@ obquit-git
 obs-backgroundremoval
 obs-backgroundremoval-deb
 obs-backgroundremoval-git
-obs-ndi-deb
 obs-studio
 obs-studio-deb
 obsidian-deb

--- a/packages/libndi4-deb/.SRCINFO
+++ b/packages/libndi4-deb/.SRCINFO
@@ -1,9 +1,0 @@
-pkgbase = libndi4-deb
-	gives = libndi4
-	pkgver = 4.5.1-1
-	pkgdesc = dependency for obs-ndi
-	arch = amd64
-	source = https://github.com/Palakis/obs-ndi/releases/download/4.9.1/libndi4_4.5.1-1_amd64.deb
-	sha256sums = d82e4231c6543ee978c85d114edd8f038c902b9be858aa6c5e847af39031f30b
-
-pkgname = libndi4-deb

--- a/packages/libndi4-deb/libndi4-deb.pacscript
+++ b/packages/libndi4-deb/libndi4-deb.pacscript
@@ -1,8 +1,0 @@
-pkgname="libndi4-deb"
-gives="libndi4"
-pkgver="4.5.1-1"
-obs_ndi_version="4.9.1"
-source=("https://github.com/Palakis/obs-ndi/releases/download/${obs_ndi_version}/libndi4_${pkgver}_amd64.deb")
-pkgdesc="dependency for obs-ndi"
-sha256sums=("d82e4231c6543ee978c85d114edd8f038c902b9be858aa6c5e847af39031f30b")
-arch=('amd64')

--- a/packages/obs-ndi-deb/.SRCINFO
+++ b/packages/obs-ndi-deb/.SRCINFO
@@ -1,9 +1,0 @@
-pkgbase = obs-ndi-deb
-	gives = obs-ndi
-	pkgver = 4.9.1
-	pkgdesc = Network A/V in OBS Studio with NewTek's NDI technology
-	arch = amd64
-	source = https://github.com/Palakis/obs-ndi/releases/download/4.9.1/obs-ndi_4.9.1-1_amd64.deb
-	sha256sums = e91a27370dcbee0879fb27ffec8dba149825f47909a92e31a001e87e64e7329b
-
-pkgname = obs-ndi-deb

--- a/packages/obs-ndi-deb/obs-ndi-deb.pacscript
+++ b/packages/obs-ndi-deb/obs-ndi-deb.pacscript
@@ -1,7 +1,0 @@
-pkgname="obs-ndi-deb"
-gives="obs-ndi"
-pkgver="4.9.1"
-source=("https://github.com/Palakis/obs-ndi/releases/download/${pkgver}/obs-ndi_${pkgver}-1_amd64.deb")
-pkgdesc="Network A/V in OBS Studio with NewTek's NDI technology"
-sha256sums=("e91a27370dcbee0879fb27ffec8dba149825f47909a92e31a001e87e64e7329b")
-arch=('amd64')

--- a/srclist
+++ b/srclist
@@ -6436,16 +6436,6 @@ pkgbase = liblcf
 
 pkgname = liblcf
 ---
-pkgbase = libndi4-deb
-	gives = libndi4
-	pkgver = 4.5.1-1
-	pkgdesc = dependency for obs-ndi
-	arch = amd64
-	source = https://github.com/Palakis/obs-ndi/releases/download/4.9.1/libndi4_4.5.1-1_amd64.deb
-	sha256sums = d82e4231c6543ee978c85d114edd8f038c902b9be858aa6c5e847af39031f30b
-
-pkgname = libndi4-deb
----
 pkgbase = libresprite-git
 	gives = libresprite
 	pkgver = 1.0
@@ -9288,16 +9278,6 @@ pkgbase = obs-backgroundremoval
 	sha256sums = 50687434e49c005a881977ea46877c00da974a10810db2ee23b0b3fbeed7d6aa
 
 pkgname = obs-backgroundremoval
----
-pkgbase = obs-ndi-deb
-	gives = obs-ndi
-	pkgver = 4.9.1
-	pkgdesc = Network A/V in OBS Studio with NewTek's NDI technology
-	arch = amd64
-	source = https://github.com/Palakis/obs-ndi/releases/download/4.9.1/obs-ndi_4.9.1-1_amd64.deb
-	sha256sums = e91a27370dcbee0879fb27ffec8dba149825f47909a92e31a001e87e64e7329b
-
-pkgname = obs-ndi-deb
 ---
 pkgbase = obs-studio-deb
 	gives = obs-studio


### PR DESCRIPTION
This PR removes 
- libndi4
- obs-ndi

Reasons to do so:
- LibNDI is 6.2.0 and not provided as a package by publisher. v4 is extremely old.
- obs-ndi is no longer a valid package, has been replaced by [DistroAV](https://github.com/DistroAV/DistroAV/)

I do not plan to test theses changes as they are removal only.

libndi4 was only a requirement for obs-ndi

Thanks