### PR TITLE
upd(btop-bin): `1.4.3` -> `1.4.4`

### DIFF
--- a/packages/btop-bin/.SRCINFO
+++ b/packages/btop-bin/.SRCINFO
@@ -1,6 +1,6 @@
 pkgbase = btop-bin
 	gives = btop
-	pkgver = 1.4.3
+	pkgver = 1.4.4
 	pkgdesc = A monitor of system resourecs, bpytop ported to C++
 	arch = amd64
 	breaks = btop
@@ -8,7 +8,7 @@ pkgbase = btop-bin
 	breaks = btop-deb
 	maintainer = wizard-28 <wiz28@pm.me>
 	repology = project: btop
-	source = https://github.com/aristocratos/btop/releases/download/v1.4.3/btop-x86_64-linux-musl.tbz
-	sha256sums = 98f11024899fea672490a2d9515f8b8b863c09f33e0e681f4fdbaa37abfd464a
+	source = https://github.com/aristocratos/btop/releases/download/v1.4.4/btop-x86_64-linux-musl.tbz
+	sha256sums = fec7d1b59c671290a0f80d5a32617ea6d60412485fc04318fd194b9550ff6b49
 
 pkgname = btop-bin

--- a/packages/btop-bin/btop-bin.pacscript
+++ b/packages/btop-bin/btop-bin.pacscript
@@ -8,11 +8,11 @@ maintainer=("wizard-28 <wiz28@pm.me>")
 
 pkgname="btop-bin"
 gives="btop"
-pkgver="1.4.3"
+pkgver="1.4.4"
 source=("https://github.com/aristocratos/btop/releases/download/v${pkgver}/btop-x86_64-linux-musl.tbz")
 pkgdesc="A monitor of system resourecs, bpytop ported to C++"
 breaks=("${gives}" "${gives}-git" "${gives}-deb")
-sha256sums=("98f11024899fea672490a2d9515f8b8b863c09f33e0e681f4fdbaa37abfd464a")
+sha256sums=("fec7d1b59c671290a0f80d5a32617ea6d60412485fc04318fd194b9550ff6b49")
 arch=('amd64')
 repology=("project: ${gives}")
 

--- a/srclist
+++ b/srclist
@@ -1192,7 +1192,7 @@ pkgname = brave-keyring-deb
 ---
 pkgbase = btop-bin
 	gives = btop
-	pkgver = 1.4.3
+	pkgver = 1.4.4
 	pkgdesc = A monitor of system resourecs, bpytop ported to C++
 	arch = amd64
 	breaks = btop
@@ -1200,8 +1200,8 @@ pkgbase = btop-bin
 	breaks = btop-deb
 	maintainer = wizard-28 <wiz28@pm.me>
 	repology = project: btop
-	source = https://github.com/aristocratos/btop/releases/download/v1.4.3/btop-x86_64-linux-musl.tbz
-	sha256sums = 98f11024899fea672490a2d9515f8b8b863c09f33e0e681f4fdbaa37abfd464a
+	source = https://github.com/aristocratos/btop/releases/download/v1.4.4/btop-x86_64-linux-musl.tbz
+	sha256sums = fec7d1b59c671290a0f80d5a32617ea6d60412485fc04318fd194b9550ff6b49
 
 pkgname = btop-bin
 ---


### PR DESCRIPTION
Does btop-bin works?
Yes.