### PR TITLE
upd(hamclock{,-big,-bigger,-huge}): `4.19` -> `4.20`

### DIFF
--- a/packages/hamclock-big/.SRCINFO
+++ b/packages/hamclock-big/.SRCINFO
@@ -1,5 +1,5 @@
 pkgbase = hamclock-big
-	pkgver = 4.19
+	pkgver = 4.20
 	pkgdesc = Clock and world map with extra features for amateur radio (1600x960 version)
 	url = https://clearskyinstitute.com/ham/HamClock
 	arch = any
@@ -19,11 +19,9 @@ pkgbase = hamclock-big
 	replaces = hamclock-huge
 	maintainer = Roy Williams <fang64@gmail.com>
 	repology = project: hamclock-big
-	source = https://github.com/fang64/hamclock/archive/refs/tags/v4.19.tar.gz
-	source = https://raw.githubusercontent.com/fang64/hamclock/refs/heads/patch/pacstall/no-updates.patch
+	source = https://github.com/fang64/hamclock/archive/refs/tags/v4.20.tar.gz
 	source = hamclock.desktop
-	sha256sums = 370d1f020c06028b35fc12a63ac26be2ab75c46b2319593349018beb5e5587df
-	sha256sums = 03dece6363a7109d3178eec7d88dafe3cea920c471d0076372acefade89294fd
+	sha256sums = 612a49653ae4d4edd43e6840d1de513b536772ffc6d347821fed76a962cfbd0f
 	sha256sums = df56e16e9bfab4a6259fd8e9fdffbe8f8d24ff395d2d27434dfd4bfe4adfa85d
 
 pkgname = hamclock-big

--- a/packages/hamclock-big/hamclock-big.pacscript
+++ b/packages/hamclock-big/hamclock-big.pacscript
@@ -1,9 +1,8 @@
 pkgname="hamclock-big"
 arch=("any")
-pkgver="4.19"
+pkgver="4.20"
 source=(
   "https://github.com/fang64/hamclock/archive/refs/tags/v${pkgver}.tar.gz"
-  "https://raw.githubusercontent.com/fang64/hamclock/refs/heads/patch/pacstall/no-updates.patch"
   "hamclock.desktop"
 )
 url='https://clearskyinstitute.com/ham/HamClock'
@@ -12,8 +11,7 @@ breaks=("hamclock" "hamclock-bigger" "hamclock-huge")
 replaces=("hamclock-big" "${breaks[@]}")
 pkgdesc="Clock and world map with extra features for amateur radio (1600x960 version)"
 sha256sums=(
-  "370d1f020c06028b35fc12a63ac26be2ab75c46b2319593349018beb5e5587df"
-  "03dece6363a7109d3178eec7d88dafe3cea920c471d0076372acefade89294fd"
+  "612a49653ae4d4edd43e6840d1de513b536772ffc6d347821fed76a962cfbd0f"
   "df56e16e9bfab4a6259fd8e9fdffbe8f8d24ff395d2d27434dfd4bfe4adfa85d"
 )
 maintainer=("Roy Williams <fang64@gmail.com>")
@@ -24,8 +22,8 @@ prepare() {
   # Add -PAC to version for PACSTALL
   sed -i 's/";/-PAC";/g' version.cpp
 
-  # Do not check for/install updates
-  patch -Np1 -i "${srcdir}/no-updates.patch"
+  # Set NO_UPGRADE definition this will disable updates
+  sed -i '18 i CXXFLAGS += -DNO_UPGRADE' Makefile
 }
 
 build() {

--- a/packages/hamclock-bigger/.SRCINFO
+++ b/packages/hamclock-bigger/.SRCINFO
@@ -1,5 +1,5 @@
 pkgbase = hamclock-bigger
-	pkgver = 4.19
+	pkgver = 4.20
 	pkgdesc = Clock and world map with extra features for amateur radio (2400x1440 version)
 	url = https://clearskyinstitute.com/ham/HamClock
 	arch = any
@@ -19,11 +19,9 @@ pkgbase = hamclock-bigger
 	replaces = hamclock-huge
 	maintainer = Roy Williams <fang64@gmail.com>
 	repology = project: hamclock-bigger
-	source = https://github.com/fang64/hamclock/archive/refs/tags/v4.19.tar.gz
-	source = https://raw.githubusercontent.com/fang64/hamclock/refs/heads/patch/pacstall/no-updates.patch
+	source = https://github.com/fang64/hamclock/archive/refs/tags/v4.20.tar.gz
 	source = hamclock.desktop
-	sha256sums = 370d1f020c06028b35fc12a63ac26be2ab75c46b2319593349018beb5e5587df
-	sha256sums = 03dece6363a7109d3178eec7d88dafe3cea920c471d0076372acefade89294fd
+	sha256sums = 612a49653ae4d4edd43e6840d1de513b536772ffc6d347821fed76a962cfbd0f
 	sha256sums = df56e16e9bfab4a6259fd8e9fdffbe8f8d24ff395d2d27434dfd4bfe4adfa85d
 
 pkgname = hamclock-bigger

--- a/packages/hamclock-bigger/hamclock-bigger.pacscript
+++ b/packages/hamclock-bigger/hamclock-bigger.pacscript
@@ -1,9 +1,8 @@
 pkgname="hamclock-bigger"
 arch=("any")
-pkgver="4.19"
+pkgver="4.20"
 source=(
   "https://github.com/fang64/hamclock/archive/refs/tags/v${pkgver}.tar.gz"
-  "https://raw.githubusercontent.com/fang64/hamclock/refs/heads/patch/pacstall/no-updates.patch"
   "hamclock.desktop"
 )
 url='https://clearskyinstitute.com/ham/HamClock'
@@ -12,8 +11,7 @@ breaks=("hamclock" "hamclock-big" "hamclock-huge")
 replaces=("hamclock-bigger" "${breaks[@]}")
 pkgdesc="Clock and world map with extra features for amateur radio (2400x1440 version)"
 sha256sums=(
-  "370d1f020c06028b35fc12a63ac26be2ab75c46b2319593349018beb5e5587df"
-  "03dece6363a7109d3178eec7d88dafe3cea920c471d0076372acefade89294fd"
+  "612a49653ae4d4edd43e6840d1de513b536772ffc6d347821fed76a962cfbd0f"
   "df56e16e9bfab4a6259fd8e9fdffbe8f8d24ff395d2d27434dfd4bfe4adfa85d"
 )
 maintainer=("Roy Williams <fang64@gmail.com>")
@@ -24,8 +22,8 @@ prepare() {
   # Add -PAC to version for PACSTALL
   sed -i 's/";/-PAC";/g' version.cpp
 
-  # Do not check for/install updates
-  patch -Np1 -i "${srcdir}/no-updates.patch"
+  # Set NO_UPGRADE definition this will disable updates
+  sed -i '18 i CXXFLAGS += -DNO_UPGRADE' Makefile
 }
 
 build() {

--- a/packages/hamclock-huge/.SRCINFO
+++ b/packages/hamclock-huge/.SRCINFO
@@ -1,5 +1,5 @@
 pkgbase = hamclock-huge
-	pkgver = 4.19
+	pkgver = 4.20
 	pkgdesc = Clock and world map with extra features for amateur radio (3200x1920 version)
 	url = https://clearskyinstitute.com/ham/HamClock
 	arch = any
@@ -19,11 +19,9 @@ pkgbase = hamclock-huge
 	replaces = hamclock-bigger
 	maintainer = Roy Williams <fang64@gmail.com>
 	repology = project: hamclock-huge
-	source = https://github.com/fang64/hamclock/archive/refs/tags/v4.19.tar.gz
-	source = https://raw.githubusercontent.com/fang64/hamclock/refs/heads/patch/pacstall/no-updates.patch
+	source = https://github.com/fang64/hamclock/archive/refs/tags/v4.20.tar.gz
 	source = hamclock.desktop
-	sha256sums = 370d1f020c06028b35fc12a63ac26be2ab75c46b2319593349018beb5e5587df
-	sha256sums = 03dece6363a7109d3178eec7d88dafe3cea920c471d0076372acefade89294fd
+	sha256sums = 612a49653ae4d4edd43e6840d1de513b536772ffc6d347821fed76a962cfbd0f
 	sha256sums = df56e16e9bfab4a6259fd8e9fdffbe8f8d24ff395d2d27434dfd4bfe4adfa85d
 
 pkgname = hamclock-huge

--- a/packages/hamclock-huge/hamclock-huge.pacscript
+++ b/packages/hamclock-huge/hamclock-huge.pacscript
@@ -1,9 +1,8 @@
 pkgname="hamclock-huge"
 arch=("any")
-pkgver="4.19"
+pkgver="4.20"
 source=(
   "https://github.com/fang64/hamclock/archive/refs/tags/v${pkgver}.tar.gz"
-  "https://raw.githubusercontent.com/fang64/hamclock/refs/heads/patch/pacstall/no-updates.patch"
   "hamclock.desktop"
 )
 url='https://clearskyinstitute.com/ham/HamClock'
@@ -12,8 +11,7 @@ breaks=("hamclock" "hamclock-big" "hamclock-bigger")
 replaces=("hamclock-huge" "${breaks[@]}")
 pkgdesc="Clock and world map with extra features for amateur radio (3200x1920 version)"
 sha256sums=(
-  "370d1f020c06028b35fc12a63ac26be2ab75c46b2319593349018beb5e5587df"
-  "03dece6363a7109d3178eec7d88dafe3cea920c471d0076372acefade89294fd"
+  "612a49653ae4d4edd43e6840d1de513b536772ffc6d347821fed76a962cfbd0f"
   "df56e16e9bfab4a6259fd8e9fdffbe8f8d24ff395d2d27434dfd4bfe4adfa85d"
 )
 maintainer=("Roy Williams <fang64@gmail.com>")
@@ -24,8 +22,8 @@ prepare() {
   # Add -PAC to version for PACSTALL
   sed -i 's/";/-PAC";/g' version.cpp
 
-  # Do not check for/install updates
-  patch -Np1 -i "${srcdir}/no-updates.patch"
+  # Set NO_UPGRADE definition this will disable updates
+  sed -i '18 i CXXFLAGS += -DNO_UPGRADE' Makefile
 }
 
 build() {

--- a/packages/hamclock/.SRCINFO
+++ b/packages/hamclock/.SRCINFO
@@ -1,5 +1,5 @@
 pkgbase = hamclock
-	pkgver = 4.19
+	pkgver = 4.20
 	pkgdesc = Clock and world map with extra features for amateur radio (800x480 version)
 	url = https://clearskyinstitute.com/ham/HamClock
 	arch = any
@@ -19,11 +19,9 @@ pkgbase = hamclock
 	replaces = hamclock-huge
 	maintainer = Roy Williams <fang64@gmail.com>
 	repology = project: hamclock
-	source = https://github.com/fang64/hamclock/archive/refs/tags/v4.19.tar.gz
-	source = https://raw.githubusercontent.com/fang64/hamclock/refs/heads/patch/pacstall/no-updates.patch
+	source = https://github.com/fang64/hamclock/archive/refs/tags/v4.20.tar.gz
 	source = hamclock.desktop
-	sha256sums = 370d1f020c06028b35fc12a63ac26be2ab75c46b2319593349018beb5e5587df
-	sha256sums = 03dece6363a7109d3178eec7d88dafe3cea920c471d0076372acefade89294fd
+	sha256sums = 612a49653ae4d4edd43e6840d1de513b536772ffc6d347821fed76a962cfbd0f
 	sha256sums = df56e16e9bfab4a6259fd8e9fdffbe8f8d24ff395d2d27434dfd4bfe4adfa85d
 
 pkgname = hamclock

--- a/packages/hamclock/hamclock.pacscript
+++ b/packages/hamclock/hamclock.pacscript
@@ -1,9 +1,8 @@
 pkgname="hamclock"
 arch=("any")
-pkgver="4.19"
+pkgver="4.20"
 source=(
   "https://github.com/fang64/hamclock/archive/refs/tags/v${pkgver}.tar.gz"
-  "https://raw.githubusercontent.com/fang64/hamclock/refs/heads/patch/pacstall/no-updates.patch"
   "hamclock.desktop"
 )
 url='https://clearskyinstitute.com/ham/HamClock'
@@ -12,8 +11,7 @@ breaks=("hamclock-big" "hamclock-bigger" "hamclock-huge")
 replaces=("hamclock" "${breaks[@]}")
 pkgdesc="Clock and world map with extra features for amateur radio (800x480 version)"
 sha256sums=(
-  "370d1f020c06028b35fc12a63ac26be2ab75c46b2319593349018beb5e5587df"
-  "03dece6363a7109d3178eec7d88dafe3cea920c471d0076372acefade89294fd"
+  "612a49653ae4d4edd43e6840d1de513b536772ffc6d347821fed76a962cfbd0f"
   "df56e16e9bfab4a6259fd8e9fdffbe8f8d24ff395d2d27434dfd4bfe4adfa85d"
 )
 maintainer=("Roy Williams <fang64@gmail.com>")
@@ -24,8 +22,9 @@ prepare() {
   # Add -PAC to version for PACSTALL
   sed -i 's/";/-PAC";/g' version.cpp
 
-  # Do not check for/install updates
-  patch -Np1 -i "${srcdir}/no-updates.patch"
+  # Set NO_UPGRADE definition this will disable updates
+  sed -i '18 i CXXFLAGS += -DNO_UPGRADE' Makefile
+
 }
 
 build() {

--- a/srclist
+++ b/srclist
@@ -4671,7 +4671,7 @@ pkgbase = hakuneko-deb
 pkgname = hakuneko-deb
 ---
 pkgbase = hamclock-big
-	pkgver = 4.19
+	pkgver = 4.20
 	pkgdesc = Clock and world map with extra features for amateur radio (1600x960 version)
 	url = https://clearskyinstitute.com/ham/HamClock
 	arch = any
@@ -4691,17 +4691,15 @@ pkgbase = hamclock-big
 	replaces = hamclock-huge
 	maintainer = Roy Williams <fang64@gmail.com>
 	repology = project: hamclock-big
-	source = https://github.com/fang64/hamclock/archive/refs/tags/v4.19.tar.gz
-	source = https://raw.githubusercontent.com/fang64/hamclock/refs/heads/patch/pacstall/no-updates.patch
+	source = https://github.com/fang64/hamclock/archive/refs/tags/v4.20.tar.gz
 	source = hamclock.desktop
-	sha256sums = 370d1f020c06028b35fc12a63ac26be2ab75c46b2319593349018beb5e5587df
-	sha256sums = 03dece6363a7109d3178eec7d88dafe3cea920c471d0076372acefade89294fd
+	sha256sums = 612a49653ae4d4edd43e6840d1de513b536772ffc6d347821fed76a962cfbd0f
 	sha256sums = df56e16e9bfab4a6259fd8e9fdffbe8f8d24ff395d2d27434dfd4bfe4adfa85d
 
 pkgname = hamclock-big
 ---
 pkgbase = hamclock-bigger
-	pkgver = 4.19
+	pkgver = 4.20
 	pkgdesc = Clock and world map with extra features for amateur radio (2400x1440 version)
 	url = https://clearskyinstitute.com/ham/HamClock
 	arch = any
@@ -4721,17 +4719,15 @@ pkgbase = hamclock-bigger
 	replaces = hamclock-huge
 	maintainer = Roy Williams <fang64@gmail.com>
 	repology = project: hamclock-bigger
-	source = https://github.com/fang64/hamclock/archive/refs/tags/v4.19.tar.gz
-	source = https://raw.githubusercontent.com/fang64/hamclock/refs/heads/patch/pacstall/no-updates.patch
+	source = https://github.com/fang64/hamclock/archive/refs/tags/v4.20.tar.gz
 	source = hamclock.desktop
-	sha256sums = 370d1f020c06028b35fc12a63ac26be2ab75c46b2319593349018beb5e5587df
-	sha256sums = 03dece6363a7109d3178eec7d88dafe3cea920c471d0076372acefade89294fd
+	sha256sums = 612a49653ae4d4edd43e6840d1de513b536772ffc6d347821fed76a962cfbd0f
 	sha256sums = df56e16e9bfab4a6259fd8e9fdffbe8f8d24ff395d2d27434dfd4bfe4adfa85d
 
 pkgname = hamclock-bigger
 ---
 pkgbase = hamclock-huge
-	pkgver = 4.19
+	pkgver = 4.20
 	pkgdesc = Clock and world map with extra features for amateur radio (3200x1920 version)
 	url = https://clearskyinstitute.com/ham/HamClock
 	arch = any
@@ -4751,17 +4747,15 @@ pkgbase = hamclock-huge
 	replaces = hamclock-bigger
 	maintainer = Roy Williams <fang64@gmail.com>
 	repology = project: hamclock-huge
-	source = https://github.com/fang64/hamclock/archive/refs/tags/v4.19.tar.gz
-	source = https://raw.githubusercontent.com/fang64/hamclock/refs/heads/patch/pacstall/no-updates.patch
+	source = https://github.com/fang64/hamclock/archive/refs/tags/v4.20.tar.gz
 	source = hamclock.desktop
-	sha256sums = 370d1f020c06028b35fc12a63ac26be2ab75c46b2319593349018beb5e5587df
-	sha256sums = 03dece6363a7109d3178eec7d88dafe3cea920c471d0076372acefade89294fd
+	sha256sums = 612a49653ae4d4edd43e6840d1de513b536772ffc6d347821fed76a962cfbd0f
 	sha256sums = df56e16e9bfab4a6259fd8e9fdffbe8f8d24ff395d2d27434dfd4bfe4adfa85d
 
 pkgname = hamclock-huge
 ---
 pkgbase = hamclock
-	pkgver = 4.19
+	pkgver = 4.20
 	pkgdesc = Clock and world map with extra features for amateur radio (800x480 version)
 	url = https://clearskyinstitute.com/ham/HamClock
 	arch = any
@@ -4781,11 +4775,9 @@ pkgbase = hamclock
 	replaces = hamclock-huge
 	maintainer = Roy Williams <fang64@gmail.com>
 	repology = project: hamclock
-	source = https://github.com/fang64/hamclock/archive/refs/tags/v4.19.tar.gz
-	source = https://raw.githubusercontent.com/fang64/hamclock/refs/heads/patch/pacstall/no-updates.patch
+	source = https://github.com/fang64/hamclock/archive/refs/tags/v4.20.tar.gz
 	source = hamclock.desktop
-	sha256sums = 370d1f020c06028b35fc12a63ac26be2ab75c46b2319593349018beb5e5587df
-	sha256sums = 03dece6363a7109d3178eec7d88dafe3cea920c471d0076372acefade89294fd
+	sha256sums = 612a49653ae4d4edd43e6840d1de513b536772ffc6d347821fed76a962cfbd0f
 	sha256sums = df56e16e9bfab4a6259fd8e9fdffbe8f8d24ff395d2d27434dfd4bfe4adfa85d
 
 pkgname = hamclock


### PR DESCRIPTION
Updated to 4.20

Removed patches to stop automatic updates, software maintainer added compile time flag to disable updates.