### PR TITLE
upd(hamclock{,-big,-bigger,-huge}): Fix pacscripts to use correct hamclock.desktop file

### DIFF
--- a/packages/hamclock-big/hamclock-big.pacscript
+++ b/packages/hamclock-big/hamclock-big.pacscript
@@ -37,6 +37,6 @@ package() {
   cp hamclock-1600x960 "${pkgdir}/usr/bin/hamclock"
   cp hamclock.png "${pkgdir}/usr/share/icons"
   cp LICENSE "${pkgdir}/usr/share/licenses/${gives}"
-  cp hamclock.desktop "${pkgdir}/usr/share/applications/hamclock.desktop"
+  cp ../../hamclock.desktop "${pkgdir}/usr/share/applications/hamclock.desktop"
   chmod -x "${pkgdir}/usr/share/applications/hamclock.desktop"
 }

--- a/packages/hamclock-bigger/hamclock-bigger.pacscript
+++ b/packages/hamclock-bigger/hamclock-bigger.pacscript
@@ -37,6 +37,6 @@ package() {
   cp hamclock-2400x1440 "${pkgdir}/usr/bin/hamclock"
   cp hamclock.png "${pkgdir}/usr/share/icons"
   cp LICENSE "${pkgdir}/usr/share/licenses/${gives}"
-  cp hamclock.desktop "${pkgdir}/usr/share/applications/hamclock.desktop"
+  cp ../../hamclock.desktop "${pkgdir}/usr/share/applications/hamclock.desktop"
   chmod -x "${pkgdir}/usr/share/applications/hamclock.desktop"
 }

--- a/packages/hamclock-huge/hamclock-huge.pacscript
+++ b/packages/hamclock-huge/hamclock-huge.pacscript
@@ -37,6 +37,6 @@ package() {
   cp hamclock-3200x1920 "${pkgdir}/usr/bin/hamclock"
   cp hamclock.png "${pkgdir}/usr/share/icons"
   cp LICENSE "${pkgdir}/usr/share/licenses/${gives}"
-  cp hamclock.desktop "${pkgdir}/usr/share/applications/hamclock.desktop"
+  cp ../../hamclock.desktop "${pkgdir}/usr/share/applications/hamclock.desktop"
   chmod -x "${pkgdir}/usr/share/applications/hamclock.desktop"
 }

--- a/packages/hamclock/hamclock.pacscript
+++ b/packages/hamclock/hamclock.pacscript
@@ -38,6 +38,6 @@ package() {
   cp hamclock-800x480 "${pkgdir}/usr/bin/hamclock"
   cp hamclock.png "${pkgdir}/usr/share/icons"
   cp LICENSE "${pkgdir}/usr/share/licenses/${gives}"
-  cp hamclock.desktop "${pkgdir}/usr/share/applications/hamclock.desktop"
+  cp ../../hamclock.desktop "${pkgdir}/usr/share/applications/hamclock.desktop"
   chmod -x "${pkgdir}/usr/share/applications/hamclock.desktop"
 }


### PR DESCRIPTION
Fix a packaging error using wrong desktop shortcut from upstream tarball points to invalid path.