### PR TITLE
upd(betterbird-bin) `128.11.0esr` -> `140.3.0esr`

### DIFF
--- a/packages/betterbird-bin/.SRCINFO
+++ b/packages/betterbird-bin/.SRCINFO
@@ -1,6 +1,6 @@
 pkgbase = betterbird-bin
 	gives = betterbird
-	pkgver = 128.11.0esr
+	pkgver = 140.3.0esr
 	pkgdesc = Fine-tuned version of Mozilla Thunderbird, Thunderbird on steroids, if you will
 	url = https://www.betterbird.eu/index.html
 	arch = x86_64
@@ -8,9 +8,9 @@ pkgbase = betterbird-bin
 	depends = hunspell
 	maintainer = tranquil <tranquiltr0@proton.me>
 	repology = project: betterbird
-	source = https://www.betterbird.eu/downloads/LinuxArchive/betterbird-128.11.0esr-bb28.en-US.linux-x86_64.tar.bz2
+	source = https://www.betterbird.eu/downloads/LinuxArchive/betterbird-140.3.0esr-bb11.en-US.linux-x86_64.tar.xz
 	source = eu.betterbird.Betterbird.desktop
-	sha256sums = 46ac8e4577f7f10e7ee8f0377a15eac644ac77b1e77a39cd05cbd2a338de45f1
+	sha256sums = 4341c8602c51f57a8aa5112e3a7d0fa954672503940561403c34ff8c05eacda4
 	sha256sums = bce809385dc48951ca6309776ed8fe5213ebbce301a790349172a799d8987151
 
 pkgname = betterbird-bin

--- a/packages/betterbird-bin/betterbird-bin.pacscript
+++ b/packages/betterbird-bin/betterbird-bin.pacscript
@@ -1,7 +1,7 @@
 pkgname="betterbird-bin"
 gives="betterbird"
-pkgver="128.11.0esr"
-_build=bb28
+pkgver="140.3.0esr"
+_build=bb11
 pkgdesc="Fine-tuned version of Mozilla Thunderbird, Thunderbird on steroids, if you will"
 maintainer=("tranquil <tranquiltr0@proton.me>")
 arch=("x86_64")
@@ -9,11 +9,11 @@ url='https://www.betterbird.eu/index.html'
 repology=("project: betterbird")
 depends=("libdbus-glib-1-2" "hunspell")
 source=(
-  "https://www.betterbird.eu/downloads/LinuxArchive/${gives}-${pkgver}-${_build}.en-US.linux-x86_64.tar.bz2"
+  "https://www.betterbird.eu/downloads/LinuxArchive/${gives}-${pkgver}-${_build}.en-US.linux-x86_64.tar.xz"
   "eu.betterbird.Betterbird.desktop"
 )
 sha256sums=(
-  "46ac8e4577f7f10e7ee8f0377a15eac644ac77b1e77a39cd05cbd2a338de45f1"
+  "4341c8602c51f57a8aa5112e3a7d0fa954672503940561403c34ff8c05eacda4"
   "bce809385dc48951ca6309776ed8fe5213ebbce301a790349172a799d8987151"
 )
 

--- a/srclist
+++ b/srclist
@@ -884,7 +884,7 @@ pkgname = bes2600-firmware-git
 ---
 pkgbase = betterbird-bin
 	gives = betterbird
-	pkgver = 128.11.0esr
+	pkgver = 140.3.0esr
 	pkgdesc = Fine-tuned version of Mozilla Thunderbird, Thunderbird on steroids, if you will
 	url = https://www.betterbird.eu/index.html
 	arch = x86_64
@@ -892,9 +892,9 @@ pkgbase = betterbird-bin
 	depends = hunspell
 	maintainer = tranquil <tranquiltr0@proton.me>
 	repology = project: betterbird
-	source = https://www.betterbird.eu/downloads/LinuxArchive/betterbird-128.11.0esr-bb28.en-US.linux-x86_64.tar.bz2
+	source = https://www.betterbird.eu/downloads/LinuxArchive/betterbird-140.3.0esr-bb11.en-US.linux-x86_64.tar.xz
 	source = eu.betterbird.Betterbird.desktop
-	sha256sums = 46ac8e4577f7f10e7ee8f0377a15eac644ac77b1e77a39cd05cbd2a338de45f1
+	sha256sums = 4341c8602c51f57a8aa5112e3a7d0fa954672503940561403c34ff8c05eacda4
 	sha256sums = bce809385dc48951ca6309776ed8fe5213ebbce301a790349172a799d8987151
 
 pkgname = betterbird-bin


### PR DESCRIPTION
- **upd(firefox-bin): `139.0.4` -> `140.0` (#7729)**
- **add: `nodejs-deb` (#7728)**
- **upd(mullvad-vpn-deb): `2025.6` -> `2025.7` (#7732)**
- **add: `libxkbcommon` (#7731)**
- **upd(yt-dlp): `2025.06.09` -> `2025.06.25` (#7733)**
- **fix(ubxi-kde-desktop-git): wayland session patch (#7740)**
- **fix(ubxi-kde-desktop-git): wayland session oops (#7741)**
- **fix(nodejs-deb): correct checksums (#7735)**
- **upd(vscodium-deb): `1.101.03933` -> `1.101.24242` (#7736)**
- **upd(discord-ptb-deb): `0.0.149` -> `0.0.150` (#7737)**
- **add: `kanata-bin` (#7730)**
- **add: `feishin-app` (#7739)**
- **upd(obs-studio-deb): `31.0.2` -> `31.0.4` (#7742)**
- **add: `osu-lazer-tachyon-app` (#7743)**
- **upd(rhino-setup-bin): `2025.3` -> `2025.3-1` (#7744)**
- **upd(rhino-setup-git): `2025.3` -> `2025.3-1` (#7745)**
- **upd(zen-browser-bin): `1.13.2b` -> `1.14b` (#7747)**
- **upd(linux-kernel-stable): `6.15.1` -> `6.15.4` (#7752)**
- **upd(linux-kernel): `6.16~rc2` -> `6.16~rc4` (#7751)**
- **upd(firefox-bin): `140.0` -> `140.0.2` (#7753)**
- **upd(firefox-deb): `139.0.4` -> `140.0.2` (#7754)**
- **upd(firefox-developer-edition-bin): `140.0b9` -> `141.0b5` (#7755)**
- **upd(firefox-nightly-bin): `141.0a1` -> `142.0a1` (#7756)**
- **upd(firefox-nightly-deb): `141.0a1` -> `142.0a1` (#7757)**
- **upd(docker-bin): `28.2.2` -> `28.3.1` (#7758)**
- **upd(docker-buildx-plugin-bin): `0.23.0` -> `0.25.0` (#7759)**
- **upd(docker-compose-plugin-bin): `2.37.1` -> `2.38.1` (#7760)**
- **upd(rhino-setup-bin): `2025.3-1` -> `2025.3-2` (#7762)**
- **upd(rhino-setup-git): `2025.3-1` -> `2025.3-2` (#7761)**
- **upd(zig-bin): `0.14.0` -> `0.14.1` (#7769)**
- **upd(wine-staging-git): `10.6` -> `10.11` (#7749)**
- **upd(rhino*core): `2025.3~RC` -> `2025.3` (#7770)**
- **rm: `firefox-arm64-deb` (#7417)**
- **upd(discord-ptb-deb): `0.0.150` -> `0.0.151` (#7763)**
- **upd(r2modman-deb): `3.2.0` -> `3.2.1` (#7765)**
- **add: `talm-bin` (#7767)**
- **upd(hydralauncher-deb): `3.6.1` -> `3.6.2` (#7764)**
- **upd(android-studio-canary): `2025.1.2.4` -> `2025.1.2.8` (#7771)**
- **upd(android-studio): `2024.3.2.15` -> `2025.1.1.13` (#7772)**
- **upd(discord): `0.0.98` -> `0.0.100` (#7773)**
- **add: `talosctl-bin` (#7768)**
- **upd(nvidia-prod-installer): `570.153.02` -> `570.169` (#7775)**
- **upd(nvidia-feat-installer): `575.57.08` -> `575.64.03` (#7776)**
- **add: `xfce4-dynamic-workspaces-rs-bin` (#7777)**
- **add: `rhino-calamares-settings-git` (#7782)**
- **upd(vesktop-deb): `1.5.7` -> `1.5.8` (#7781)**
- **upd(obs-studio): `31.0.3` -> `31.1.0` (#7779)**
- **upd(obs-studio-deb): `31.0.4` -> `31.1.0` (#7778)**
- **ci(srcinfo.sh): drop mips (#7783)**
- **upd(pacstall): `6.3.2` -> `6.3.3` (#7784)**
- **upd(mold-bin): `2.40.0` -> `2.40.1` (#7785)**
- **upd(zen-browser-bin): `1.14b` -> `1.14.3b` (#7787)**
- **upd(distrolist): rm `oracular/24.10` (#7786)**
- **upd(ulauncher-deb): `6.0.0~beta19` -> `6.0.0~beta20` (#7788)**
- **upd(osu-lazer-tachyon-app): `2025.625.0` -> `2025.710.0` (#7790)**
- **upd(osu-lazer-app): `2025.607.0` -> `2025.710.0` (#7789)**
- **upd(obs-studio-deb): `31.1.0` -> `31.1.1` (#7791)**
- **upd(an-anime-game-launcher-bin): `3.14.3` -> `3.15.0` (#7794)**
- **upd(discord-ptb-deb): `0.0.151` -> `0.0.152` (#7793)**
- **upd(obs-studio): `31.1.0` -> `31.1.1` (#7792)**
- **fix(rhino-system-git): ensure script deps are installed (#7795)**
- **upd(linux-kernel-stable): `6.15.4` -> `6.15.6` (#7796)**
- **upd(linux-kernel): `6.16~rc4` -> `6.16~rc5` (#7797)**
- **upd(firefox-deb): `140.0.2` -> `140.0.4` (#7798)**
- **upd(firefox-bin): `140.0.2` -> `140.0.4` (#7799)**
- **upd(firefox-developer-edition-bin): `141.0b5` -> `141.0b9` (#7800)**
- **upd(pacstall): `6.3.3` -> `6.3.4` (#7801)**
- **fix(ly-git): update repo url (#7802)**
- **upd(ly): `1.1.0` -> `1.1.1` (#7803)**
- **fix(vinegar-git): include `git_pkgver` (#7804)**
- **upd(abdownloadmanager): `1.6.4` -> `1.6.6` (#7805)**
- **add: `keyd-deb` (#7807)**
- **fix(capsfix-git): use new method (#7809)**
- **add: `kubeswitch-bin` (#7810)**
- **upd(feishin-app): `0.16.0` -> `0.18.0` (#7806)**
- **[pre-commit.ci] pre-commit autoupdate (#7808)**
- **fix(capsfix-git,nvidia*installer): cleanup postinst/upg notes (#7819)**
- **fix(`git-credential-manager-core`): use new source (#7811)**
- **upd(anydesk-deb): `7.0.0` -> `7.0.2` (#7812)**
- **upd(bitwarden-deb): `2025.5.1` -> `2025.6.1` (#7813)**
- **upd(protonplus): `0.5.5` -> `0.5.10` (#7814)**
- **upd(btop-bin): `1.4.3` -> `1.4.4` (#7815)**
- **upd(thunderbird-bin): `133.0` -> `140.0.1` (#7816)**
- **upd(drawio-desktop-deb): `27.0.9` -> `28.0.4` (#7817)**
- **upd(lazygit): `0.52.0` -> `0.53.0` (#7818)**
- **upd(git-credential-manager-core-deb): `2.4.1` -> `2.6.1` (#7820)**
- **upd(yt-dlp): `2025.06.25` -> `2025.06.30` (#7822)**
- **upd(telegram-bin): `5.15.4` -> `5.16.4` (#7827)**
- **upd(kdenlive-app): `25.04.2` -> `25.04.3` (#7833)**
- **upd(digikam-app): `8.6.0` -> `8.7.0` (#7832)**
- **upd(osu-lazer-tachyon-app): `2025.710.0` -> `2025.715.0` (#7830)**
- **upd(ungoogled-chromium-bin): `136.0.7103.113-1` -> `138.0.7204.100-1` (#7829)**
- **upd(blender-bin): `4.4.3` -> `4.5.0` (#7826)**
- **upd(bitwarden-cli-bin): `2025.5.0` -> `2025.6.1` (#7825)**
- **upd(android-studio): `2025.1.1.13` -> `2025.1.1.14` (#7824)**
- **upd(anydesk-bin): `7.0.0` -> `7.0.2` (#7823)**
- **add: `hayase-deb` (#7831)**
- **add: `ppsspp-git` (#7834)**
- **upd(amfora-bin): `1.10.0` -> `1.11.0` (#7837)**
- **upd(mullvad-vpn-beta-deb): `2025.7-beta1` -> `2025.8-beta1` (#7836)**
- **upd(anytype-deb): `0.47.3` -> `0.47.6` (#7838)**
- **upd(exiftool): `13.31` -> `13.32` (#7839)**
- **fix(ppsspp-git): correct repology (#7840)**
- **add: `ppsspp-app` (#7841)**
- **upd(onefetch-bin): `2.24.0` -> `2.25.0` (#7842)**
- **upd(opera-developer-deb): `119.0.5495.0` -> `121.0.5586.0` (#7846)**
- **upd(opensnitch-deb): `1.6.6` -> `1.7.1` (#7843)**
- **upd(opensnitch-ui-deb): `1.6.6` -> `1.7.1` (#7844)**
- **upd(opera-deb): `118.0.5461.60` -> `120.0.5543.93` (#7845)**
- **upd(osu-lazer-tachyon-app): `2025.715.0` -> `2025.718.0` (#7848)**
- **upd(rpcs3-app): `0.0.34-17339` -> `0.0.37-18022` (#7849)**
- **upd(pcsx2-app): `2.2.0` -> `2.4.0` (#7850)**
- **upd(cromite-bin): `132.0.6834.163` -> `138.0.7204.97` (#7851)**
- **upd(krita-app): `5.2.9` -> `5.2.11` (#7852)**
- **upd(brave-browser-deb): `1.79.126` -> `1.80.122` (#7855)**
- **upd(brave-keyring-deb): `1.17` -> `1.18` (#7856)**
- **upd(hayase-deb): `6.4.13` -> `6.4.15` (#7857)**
- **upd(nvidia-prod-installer): `570.169` -> `570.172.08` (#7858)**
- **fix(nvidia-beta-installer): `arm64` support (#7859)**
- **fix(nvidia-feat-installer): `arm64` support (#7860)**
- **upd(linux-kernel-stable): `6.15.6` -> `6.15.7` (#7861)**
- **upd(linux-kernel): `6.16~rc5` -> `6.16~rc6` (#7862)**
- **add: `lxterminal` (#7854)**
- **upd(postman-bin): `11.49.4` -> `11.54.6` (#7863)**
- **upd(chezmoi-deb): `2.62.6` -> `2.63.0` (#7864)**
- **upd(pgadmin4-{server,desktop}-deb): `9.4` -> `9.5` (#7865)**
- **upd(brave-browser-beta-deb): `1.80.108` -> `1.81.120` (#7878)**
- **upd(yt-dlp): `2025.06.30` -> `2025.07.21` (#7879)**
- **upd(brave-browser-nightly-deb): `1.81.94` -> `1.82.102` (#7871)**
- **upd(discord): `0.0.100` -> `0.0.102` (#7873)**
- **upd(opera-beta-deb): `120.0.5543.12` -> `120.0.5543.53` (#7877)**
- **upd(yt-dlp): `2025.06.30` -> `2025.07.21` (#7876)**
- **upd(git): `2.50.0` -> `2.50.1` (#7875)**
- **upd(discord-deb): `0.0.98` -> `0.0.102` (#7874)**
- **upd(chwp-deb): `1.239.37` -> `1.239.38` (#7872)**
- **upd(nerd-fonts-fira-code): `3.1.1` -> `3.4.0` (#7880)**
- **upd(nerd-fonts-jetbrains-mono): `3.1.1` -> `3.4.0` (#7881)**
- **add: `jsonnet-bundler-bin` (#7866)**
- **upd(aseprite): `1.3.9` -> `1.3.14.4` (#7869)**
- **upd(osu-lazer-tachyon-app): `2025.718.0` -> `2025.721.0` (#7868)**
- **add: `fblog-bin` (#7867)**
- **upd(firefox-bin): `140.0.4` -> `141.0` (#7882)**
- **upd(hayase-deb): `6.4.15` -> `6.4.16` (#7884)**
- **upd(chezmoi-deb): `2.63.0` -> `2.63.1` (#7885)**
- **upd(docker-bin): `28.3.1` -> `28.3.2` (#7886)**
- **upd(electerm-deb): `1.91.16` -> `1.100.20` (#7887)**
- **rm: `fblog-deb` (#7888)**
- **upd(floorp-bin): `11.27.0` -> `12.0.15` (#7889)**
- **upd(brave-browser-deb): `1.80.122` -> `1.80.124` (#7890)**
- **upd(osu-lazer-tachyon-app): `2025.721.0` -> `2025.724.2` (#7893)**
- **upd(discord-ptb-deb): `0.0.152` -> `0.0.153` (#7894)**
- **upd(kwin-krohnkite) `0.9.9.1 -> 0.9.9.2` (#7895)**
- **add: `kakoune-lsp` (#7892)**
- **upd(xfce4-dynamic-workspaces-rs-bin): `0.2.0` -> `0.3.0` (#7902)**
- **upd(firefox-nightly-deb): `142.0a1` -> `143.0a1` (#7901)**
- **upd(firefox-nightly-bin): `142.0a1` -> `143.0a1` (#7900)**
- **upd(firefox-developer-edition-bin): `141.0b9` -> `142.0b3` (#7899)**
- **upd(firefox-deb): `140.0.4` -> `141.0` (#7898)**
- **ci(codacy): remove it (#7903)**
- **upd(librewolf-app): `139.0.4-1` -> `140.0.4-1` (#7911)**
- **upd(r2modman-deb): `3.2.1` -> `3.2.2` (#7916)**
- **upd(hydralauncher-deb): `3.6.2` -> `3.6.3` (#7915)**
- **upd(librewolf-deb): `139.0.4-1` -> `140.0.4-1` (#7910)**
- **upd(heroic-games-launcher-deb): `2.17.2` -> `2.18.0` (#7909)**
- **upd(fzf-bin): `0.62.0` -> `0.65.0` (#7908)**
- **upd(nerd-fonts-hack): `3.1.1` -> `3.4.0` (#7907)**
- **upd(exiftool): `13.32` -> `13.33` (#7906)**
- **upd(bitwarden-cli-bin): `2025.6.1` -> `2025.7.0` (#7905)**
- **upd(bitwarden-deb): `2025.6.1` -> `2025.7.0` (#7904)**
- **add: `rofi`,`rofi-dev` (#7847)**
- **add: `erlang-jsone` (#7891)**
- **add: `wayland-git` (#7897)**
- **upd(obs-studio-deb): `31.1.1` -> `31.1.2` (#7920)**
- **upd(obs-studio): `31.1.1` -> `31.1.2` (#7923)**
- **upd(osu-lazer-tachyon-app): `2025.724.2` -> `2025.729.0` (#7924)**
- **upd(electerm-deb): `1.100.20` -> `1.100.30` (#7930)**
- **upd(discord-deb): `0.0.102` -> `0.0.103` (#7929)**
- **upd(discord): `0.0.102` -> `0.0.103` (#7928)**
- **upd(blender-bin): `4.5.0` -> `4.5.1` (#7927)**
- **upd(balena-etcher-deb): `2.1.3` -> `2.1.4` (#7931)**
- **upd(hayase-deb): `6.4.16` -> `6.4.18` (#7926)**
- **upd(icecat-deb): `115.24.0` -> `128.12.0` (#7932)**
- **upd(sublime-merge-deb): `2108` -> `2110` (#7933)**
- **upd(thunderbird-bin): `140.0.1` -> `141.0` (#7934)**
- **upd(an-anime-game-launcher-bin): `3.15.0` -> `3.15.4` (#7936)**
- **upd(discord-ptb-deb): `0.0.153` -> `0.0.154` (#7938)**
- **add: `libfdk-aac2-deb` (#7939)**
- **upd(hayase-deb): `6.4.18` -> `6.4.19` (#7941)**
- **fix(wayland-git): build and install for 32-bit too (#7940)**
- **add: `jq-bin` (#7925)**
- **fix(wayland-protocols-git): use `wayland-git` pacdep (#7922)**
- **upd(nushell-bin): `0.104.0` -> `0.106.0` (#7917)**
- **upd(nutext-bin): `0.3.4` -> `0.5.0` (#7918)**
- **upd(nutext-git): `0.3.4` -> `0.5.0` (#7919)**
- **add: `kakoune-kakboard-git` (#7912)**
- **upd(lazygit): `0.53.0` -> `0.54.0` (#7943)**
- **upd(rhino-pkg-git): `2.0.1` -> `2.0.2` (#7944)**
- **upd(unicorn-{desktop,mobile}-git): switch to rs workspaces plugin (#7945)**
- **upd(lightpad-git): `0.0.8` -> `0.1.0` (#7946)**
- **upd(rhino-pkg-git): `2.0.2` -> `2.0.3` (#7947)**
- **upd(pacstall): `6.3.4` -> `6.3.5` (#7948)**
- **add: `kakoune-auto-pairs-git` (#7914)**
- **upd(hayase-deb): `6.4.19` -> `6.4.21` (#7950)**
- **upd(rustdesk-deb): `1.4.0` -> `1.4.1` (#7949)**
- **add: `libfdk-aac-dev-deb` (#7952)**
- **add: `kakoune-powerline-git` (#7913)**
- **upd(firefox-bin): `141.0` -> `141.0.2` (#7956)**
- **upd(hamclock{,-big,-bigger,-huge}): `4.19` -> `4.20` (#7957)**
- **upd(discord): `0.0.103` -> `0.0.104` (#7959)**
- **ci(tests): de-duplicate (#7974)**
- **upd(teams-for-linux-deb): `2.0.18` -> `2.1.3` (#7953)**
- **upd(osu-lazer-tachyon-app): `2025.729.0` -> `2025.808.0` (#7954)**
- **upd(discord-deb): `0.0.103` -> `0.0.104` (#7961)**
- **upd(discord-canary-deb): `0.0.702` -> `0.0.735` (#7962)**
- **upd(discord-canary): `0.0.702` -> `0.0.735` (#7963)**
- **upd(brave-browser-deb): `1.80.124` -> `1.81.131` (#7964)**
- **upd(opera-deb): `120.0.5543.93` -> `120.0.5543.161` (#7967)**
- **upd(brave-browser-beta-deb): `1.81.120` -> `1.82.139` (#7968)**
- **upd(firefox-deb): `141.0` -> `141.0.3` (#7970)**
- **upd(brave-browser-nightly-deb): `1.82.102` -> `1.83.19` (#7969)**
- **upd(cromite-bin): `138.0.7204.97` -> `138.0.7204.184` (#7960)**
- **upd(firefox-bin): `141.0.2` -> `141.0.3` (#7971)**
- **upd(firefox-developer-edition-bin): `142.0b3` -> `142.0b8` (#7972)**
- **upd(linux-kernel{,-stable}): `6.15.7` -> `6.16` (#7973)**
- **upd(distrolist): add `forky/14` (#7975)**
- **upd(github-cli-bin): `2.74.2` -> `2.76.2` (#7976)**
- **upd(github-cli-deb): `2.74.2` -> `2.76.2` (#7977)**
- **upd(vscode-deb): `1.100.0` -> `1.103.0` (#7978)**
- **upd(bottom-deb): `0.10.2` -> `0.11.0` (#7979)**
- **upd(electerm-deb): `1.100.30` -> `1.100.46` (#7980)**
- **upd(electronmail-deb): `5.3.0` -> `5.3.2` (#7981)**
- **upd(floorp-bin): `12.0.15` -> `12.0.16` (#7982)**
- **upd(git-delta-deb): `0.17.0` -> `0.18.2` (#7983)**
- **upd(lazygit): `0.54.0` -> `0.54.1` (#7984)**
- **upd(librewolf-app): `140.0.4-1` -> `141.0.2-1` (#7985)**
- **upd(hayase-deb): `6.4.21` -> `6.4.22` (#7987)**
- **add: `imhex-app` (#7988)**
- **upd(nvidia-prod-installer): `570.172.08` -> `570.181` (#7989)**
- **upd(nvidia-feat-installer): `575.64.03` -> `575.64.05` (#7990)**
- **upd(nvidia-beta-installer): `575.51.02` -> `580.65.06` (#7991)**
- **upd(lazygit): `0.54.1` -> `0.54.2` (#7992)**
- **upd(abdownloadmanager): `1.6.6` -> `1.6.8` (#7994)**
- **upd(postman-bin): `11.54.6` -> `11.57.6` (#7995)**
- **upd(discord-ptb-deb): `0.0.154` -> `0.0.155` (#7996)**
- **ci(distrolist): use ci prefix instead of upd**
- **upd(osu-lazer-tachyon-app): `2025.808.0` -> `2025.813.0` (#8002)**
- **upd(zen-browser-bin): `1.14.3b` -> `1.14.11b` (#8001)**
- **add: `ffmpeg` (#7955)**
- **upd(hayase-deb): `6.4.22` -> `6.4.23` (#8005)**
- **upd(osu-lazer-tachyon-app): `2025.813.0` -> `2025.815.0` (#8007)**
- **upd(thunderbird-esr-bin): `128.6.0esr` -> `140.1.1esr` (#8008)**
- **upd(brave-browser-nightly-deb): `1.83.19` -> `1.83.50` (#8010)**
- **upd(an-anime-game-launcher-bin): `3.15.4` -> `3.15.5` (#8009)**
- **upd(discord-ptb-deb): `0.0.155` -> `0.0.156` (#8011)**
- **upd(osu-lazer-app): `2025.710.0` -> `2025.816.0` (#8014)**
- **upd(waydroid-deb and deps): `1.4.3` -> `1.5.4` (#8012)**
- **ci(deps): bump actions/checkout from 4 to 5 (#7997)**
- **[pre-commit.ci] pre-commit autoupdate (#7993)**
- **ci: fix precommit (#8020)**
- **fix(hamclock{,-big,-bigger,-huge}): Fix pacscripts to use correct hamclock.desktop file (#8024)**
- **upd(android-studio): `2025.1.1.14` -> `2025.1.2.12` (#8025)**
- **upd(linux-kernel-stable): `6.16` -> `6.16.1` (#8021)**
- **upd(linux-kernel): `6.16` -> `6.17~rc1` (#8022)**
- **upd(mullvad-vpn-deb): `2025.7` -> `2025.8` (#8028)**
- **upd(osu-lazer-tachyon-app): `2025.815.0` -> `2025.822.0` (#8027)**
- **upd(an-anime-game-launcher): `3.15.5` -> `3.15.6` (#8029)**
- **add: `rofi-emoji` (#8016)**
- **add: `i3status-rust` (#8015)**
- **add: `carla-git` (#8030)**
- **add: `lmms-git` (#8019)**
- **upd(zen-browser-bin): `1.14.11b` -> `1.15b` (#8032)**
- **upd(osu-lazer-tachyon-app): `2025.815.0` -> `2025.827.0` (#8034)**
- **upd(ly): `1.1.1` -> `1.1.2` (#8037)**
- **add: `rose-pine-cursor` (#8033)**
- **upd(zen-browser-bin): `1.15b` -> `1.15.1b` (#8039)**
- **upd(zen-browser-bin): `1.15.1b` -> `1.15.2b` (#8041)**
- **upd(brave-browser-nightly-deb): `1.83.50` -> `1.84.13` (#8043)**
- **upd(brave-browser-beta-deb): `1.82.139` -> `1.83.89` (#8044)**
- **upd(brave-browser-deb): `1.81.131` -> `1.81.136` (#8045)**
- **upd(neovim-app): `0.11.0` -> `0.11.4` (#8047)**
- **upd(neovim): `0.11.2` -> `0.11.4` (#8046)**
- **upd(neovim-git): `0.11.0` -> `0.11.4` (#8048)**
- **upd(feishin-app): `0.18.0` -> `0.19.0` (#8050)**
- **upd(webcord-deb): `4.11.0` -> `4.11.1` (#8049)**
- **upd(osu-lazer-tachyon-app): `2025.827.0` -> `2025.905.0` (#8051)**
- **upd(discord): `0.0.104` -> `0.0.108` (#8053)**
- **upd(linux-kernel-stable): `6.16.1` -> `6.16.5` (#8054)**
- **upd(linux-kernel): `6.17~rc1` -> `6.17~rc4` (#8055)**
- **upd(naps2-deb): `8.2.0` -> `8.2.1` (#8058)**
- **fix(openrgb-git): fixed pacscript (#8042)**
- **add: `kakoune-tree-sitter` (#8052)**
- **add: `vinegar` (#8040)**
- **upd(zen-browser-bin): `1.15.2b` -> `1.15.5b` (#8059)**
- **upd(osu-lazer-tachyon-app): `2025.905.0` -> `2025.911.0` (#8060)**
- **add: `wine-staging` (#8038)**
- **upd(osu-lazer-app): `2025.816.0` -> `2025.912.0` (#8061)**
- **upd(hayase-deb): `6.4.23` -> `6.4.29` (#8062)**
- **upd(hydralauncher-deb): `3.6.3` -> `3.6.8` (#8065)**
- **upd(lazygit): `0.54.2` -> `0.55.0` (#8064)**
- **upd(hayase-deb): `6.4.29` -> `6.4.31` (#8067)**
- **add: `bluetuith-bin` (#8066)**
- **upd(firefox-bin): `141.0.3` -> `142.0.1` (#8070)**
- **upd(firefox-deb): `141.0.3` -> `142.0.1` (#8071)**
- **upd(firefox-developer-edition-bin): `142.0b8` -> `143.0b9` (#8072)**
- **upd(firefox-nightly-deb): `143.0a1` -> `144.0a1` (#8073)**
- **upd(firefox-nightly-bin): `143.0a1` -> `144.0a1` (#8074)**
- **upd(linux-kernel-stable): `6.16.5` -> `6.16.7` (#8075)**
- **upd(sleepy-launcher-bin): `1.3.0` -> `1.4.0` (#8080)**
- **upd(honkers-launcher-bin): `1.10.2` -> `1.11.0` (#8079)**
- **upd(the-honkers-railway-launcher-bin): `1.10.0` -> `1.11.1` (#8078)**
- **upd(an-anime-game-launcher-bin): `3.15.6` -> `3.16.0` (#8077)**
- **upd(linux-kernel): `6.17~rc4` -> `6.17~rc6` (#8076)**
- **upd(betterbird-bin) `128.11.0esr` -> `140.3.0esr`**
