### PR TITLE
upd(bitwarden-cli-bin): `2025.7.0` -> `2025.9.0`

### DIFF
--- a/packages/bitwarden-cli-bin/.SRCINFO
+++ b/packages/bitwarden-cli-bin/.SRCINFO
@@ -1,13 +1,13 @@
 pkgbase = bitwarden-cli-bin
 	gives = bitwarden-cli
-	pkgver = 2025.7.0
+	pkgver = 2025.9.0
 	pkgdesc = Bitwarden's command-line interface - Binary
 	arch = amd64
 	breaks = bitwarden-cli-git
 	replaces = bitwarden-cli
 	maintainer = Elsie19 <elsie19@pm.me>
 	repology = project: bitwarden-cli
-	source = https://github.com/bitwarden/clients/releases/download/cli-v2025.7.0/bw-linux-2025.7.0.zip
-	sha256sums = b0bdaaa1f77d8dbf304e37403fa57a54aa1dafbe7c660d120ad67f286c174adf
+	source = https://github.com/bitwarden/clients/releases/download/cli-v2025.9.0/bw-linux-2025.9.0.zip
+	sha256sums = 91083a77b9e6781ef4088ef94c22651c3368d3ccff9fe3938f6f0316eae8d417
 
 pkgname = bitwarden-cli-bin

--- a/packages/bitwarden-cli-bin/bitwarden-cli-bin.pacscript
+++ b/packages/bitwarden-cli-bin/bitwarden-cli-bin.pacscript
@@ -2,14 +2,15 @@ pkgname="bitwarden-cli-bin"
 gives="bitwarden-cli"
 repology=("project: ${gives}")
 arch=("amd64")
-pkgver="2025.7.0"
+pkgver="2025.9.0"
 source=("https://github.com/bitwarden/clients/releases/download/cli-v${pkgver}/bw-linux-${pkgver}.zip")
 breaks=("${gives}-git")
 replaces=("${gives}")
 pkgdesc="Bitwarden's command-line interface - Binary"
-sha256sums=("b0bdaaa1f77d8dbf304e37403fa57a54aa1dafbe7c660d120ad67f286c174adf")
+sha256sums=("91083a77b9e6781ef4088ef94c22651c3368d3ccff9fe3938f6f0316eae8d417")
 maintainer=("Elsie19 <elsie19@pm.me>")
 
 package() {
   install -Dm755 ./bw -t "${pkgdir}/usr/bin"
+  ./bw completion --shell zsh | install -Dm644 /dev/stdin "${pkgdir}/usr/share/zsh/site-functions/_bw"
 }

--- a/srclist
+++ b/srclist
@@ -901,15 +901,15 @@ pkgname = betterbird-bin
 ---
 pkgbase = bitwarden-cli-bin
 	gives = bitwarden-cli
-	pkgver = 2025.7.0
+	pkgver = 2025.9.0
 	pkgdesc = Bitwarden's command-line interface - Binary
 	arch = amd64
 	breaks = bitwarden-cli-git
 	replaces = bitwarden-cli
 	maintainer = Elsie19 <elsie19@pm.me>
 	repology = project: bitwarden-cli
-	source = https://github.com/bitwarden/clients/releases/download/cli-v2025.7.0/bw-linux-2025.7.0.zip
-	sha256sums = b0bdaaa1f77d8dbf304e37403fa57a54aa1dafbe7c660d120ad67f286c174adf
+	source = https://github.com/bitwarden/clients/releases/download/cli-v2025.9.0/bw-linux-2025.9.0.zip
+	sha256sums = 91083a77b9e6781ef4088ef94c22651c3368d3ccff9fe3938f6f0316eae8d417
 
 pkgname = bitwarden-cli-bin
 ---


### PR DESCRIPTION
Updated bitwarden-cli, and also added installation to the zsh completion (it does not provide completion for other shells).