### PR TITLE
Update gearlever-git.pacscript

### DIFF
--- a/packages/gearlever-git/gearlever-git.pacscript
+++ b/packages/gearlever-git/gearlever-git.pacscript
@@ -18,8 +18,6 @@ prepare() {
   sed -i "s/7zz/7z/g" src/providers/AppImageProvider.py
   sed -i "s|get_appimage_offset|/usr/lib/gearlever/get_appimage_offset|g" src/providers/AppImageProvider.py
   find . -name "meson.build" -exec sed -i 's/\.path()/\.full_path()/g' {} +
-
-  meson setup build/ --buildtype=release --prefix=/usr
 }
 
 build() {


### PR DESCRIPTION
There's a duplicated line that's corrupting meson.build version number.

`meson setup build/ --buildtype=release --prefix=/usr`