### PR TITLE
upd(kanata-bin) `1.9.0` -> `1.10.0`

### DIFF
--- a/packages/kanata-bin/.SRCINFO
+++ b/packages/kanata-bin/.SRCINFO
@@ -8,6 +8,7 @@ pkgbase = kanata-bin
 	depends = libc-bin
 	depends = systemd
 	provides = kanata
+	backup = etc/kanata/config.kbd
 	license = LGPL-3.0-only
 	maintainer = tranquil <tranquiltr0@proton.me>
 	repology = project: kanata

--- a/packages/kanata-bin/kanata-bin.pacscript
+++ b/packages/kanata-bin/kanata-bin.pacscript
@@ -17,6 +17,7 @@ sha256sums=(
   'fe6ba3768c1a7a60d94628a613f168f464b7ab88d34077e26896a7d3967e5eb6'
   'a5681bf9b05db14d86776930017c647ad9e6e56ff6bbcfdf21e5848288dfaf1b'
 )
+backup=('etc/kanata/config.kbd')
 
 package() {
 

--- a/srclist
+++ b/srclist
@@ -6189,6 +6189,7 @@ pkgbase = kanata-bin
 	depends = libc-bin
 	depends = systemd
 	provides = kanata
+	backup = etc/kanata/config.kbd
 	license = LGPL-3.0-only
 	maintainer = tranquil <tranquiltr0@proton.me>
 	repology = project: kanata


### PR DESCRIPTION
I would like to not overwrite the config file every time, in debian packaging that would be DEBIAN/conffiles, is there any way to avoid doing so here? I would appreciate any guidance, thanks!
