### PR TITLE
fix(plasma-compact-shutdown-git): Make the buttons actually do something

### DIFF
--- a/packages/plasma-compact-shutdown-git/.SRCINFO
+++ b/packages/plasma-compact-shutdown-git/.SRCINFO
@@ -1,6 +1,7 @@
 pkgbase = plasma-compact-shutdown-git
 	gives = plasma-compact-shutdown
 	pkgver = 1.2
+	pkgrel = 2
 	pkgdesc = KDE applet for a compact shutdown menu
 	url = https://github.com/ChickenLegsOz/org.kde.plasma.compact-shutdown
 	arch = all

--- a/packages/plasma-compact-shutdown-git/plasma-compact-shutdown-git.pacscript
+++ b/packages/plasma-compact-shutdown-git/plasma-compact-shutdown-git.pacscript
@@ -1,15 +1,21 @@
-pkgname="plasma-compact-shutdown-git"
-gives="plasma-compact-shutdown"
-pkgdesc="KDE applet for a compact shutdown menu"
-pkgver="1.2"
-arch=("all")
+pkgname='plasma-compact-shutdown-git'
+gives='plasma-compact-shutdown'
+pkgdesc='KDE applet for a compact shutdown menu'
+pkgver='1.2'
+pkgrel='2'
+arch=('all')
 breaks=("${gives}")
 url='https://github.com/ChickenLegsOz/org.kde.plasma.compact-shutdown'
 source=("${pkgname}::https://github.com/ChickenLegsOz/org.kde.plasma.compact-shutdown.git")
 sha256sums=('SKIP')
-license=("GPL-3.0-only")
-maintainer=("Erik Hedlund <erikcghedlund@outlook.com>")
-depends=("plasma-desktop>=4:6.0.0")
+license=('GPL-3.0-only')
+maintainer=('Erik Hedlund <erikcghedlund@outlook.com>')
+depends=('plasma-desktop>=4:6.0.0')
+
+prepare() {
+  # This is really something that should be fixed upstream, but this fixes it for now
+  sed -i 's/\bqdbus\b/qdbus6/' "${srcdir}/${pkgname}/package/contents/ui/main.qml"
+}
 
 package() {
   destdir="${pkgdir}/usr/local/share/plasma/plasmoids/org.kde.plasma.compact-shutdown"

--- a/srclist
+++ b/srclist
@@ -11544,6 +11544,7 @@ pkgname = planner-git
 pkgbase = plasma-compact-shutdown-git
 	gives = plasma-compact-shutdown
 	pkgver = 1.2
+	pkgrel = 2
 	pkgdesc = KDE applet for a compact shutdown menu
 	url = https://github.com/ChickenLegsOz/org.kde.plasma.compact-shutdown
 	arch = all


### PR DESCRIPTION
The add-on calls qdbus which has been renamed to qdbus6 in Plasma. This fixes the applet so that pressing the buttons actually does something 