### PR TITLE
add: `xapp-symbolic-icons-deb`

### DIFF
--- a/packagelist
+++ b/packagelist
@@ -855,6 +855,7 @@ wine-staging-git
 winetricks-git
 wlrobs
 wsysmon-bin
+xapp-symbolic-icons-deb
 xapps-common-deb
 xcb-util-errors
 xclicker-deb

--- a/packages/xapp-symbolic-icons-deb/.SRCINFO
+++ b/packages/xapp-symbolic-icons-deb/.SRCINFO
@@ -1,0 +1,11 @@
+pkgbase = xapp-symbolic-icons-deb
+	gives = xapp-symbolic-icons
+	pkgver = 1.0.9
+	pkgdesc = Set of symbolic icons for GTK applications
+	arch = all
+	maintainer = Zahrun <zahrunAtmurenaDotio>
+	repology = project: xapp-symbolic-icons
+	source = http://packages.linuxmint.com/pool/main/x/xapp-symbolic-icons/xapp-symbolic-icons_1.0.9_all.deb
+	sha256sums = dd99f740af5f4d1c374f3116748ec8e8c6ca791d2ce666e711d7f735a1b52ba5
+
+pkgname = xapp-symbolic-icons-deb

--- a/packages/xapp-symbolic-icons-deb/xapp-symbolic-icons-deb.pacscript
+++ b/packages/xapp-symbolic-icons-deb/xapp-symbolic-icons-deb.pacscript
@@ -1,0 +1,9 @@
+pkgname="xapp-symbolic-icons-deb"
+gives="xapp-symbolic-icons"
+arch=("all")
+pkgver="1.0.9"
+repology=("project: xapp-symbolic-icons")
+source=("http://packages.linuxmint.com/pool/main/x/xapp-symbolic-icons/xapp-symbolic-icons_${pkgver}_all.deb")
+sha256sums=("dd99f740af5f4d1c374f3116748ec8e8c6ca791d2ce666e711d7f735a1b52ba5")
+pkgdesc="Set of symbolic icons for GTK applications"
+maintainer=("Zahrun <zahrunAtmurenaDotio>")

--- a/srclist
+++ b/srclist
@@ -17062,6 +17062,18 @@ pkgbase = wsysmon-bin
 
 pkgname = wsysmon-bin
 ---
+pkgbase = xapp-symbolic-icons-deb
+	gives = xapp-symbolic-icons
+	pkgver = 1.0.9
+	pkgdesc = Set of symbolic icons for GTK applications
+	arch = all
+	maintainer = Zahrun <zahrunAtmurenaDotio>
+	repology = project: xapp-symbolic-icons
+	source = http://packages.linuxmint.com/pool/main/x/xapp-symbolic-icons/xapp-symbolic-icons_1.0.9_all.deb
+	sha256sums = dd99f740af5f4d1c374f3116748ec8e8c6ca791d2ce666e711d7f735a1b52ba5
+
+pkgname = xapp-symbolic-icons-deb
+---
 pkgbase = xapps-common-deb
 	gives = xapps-common
 	pkgver = 2.8.2


### PR DESCRIPTION
This package contains a set of symbolic icons which replaces the GNOME-specific
  Adwaita set. All provided icons are prefixed with xsi- and places in
  /usr/share/icons/hicolor. Icon names loosely follow the Adwaita names.

new dependency for xapps-comon-deb