### PR TITLE
upd(hamclock{,-big,-bigger,-huge}): `4.21` -> `4.22`

### DIFF
--- a/packages/hamclock-big/.SRCINFO
+++ b/packages/hamclock-big/.SRCINFO
@@ -1,5 +1,5 @@
 pkgbase = hamclock-big
-	pkgver = 4.21
+	pkgver = 4.22
 	pkgdesc = Clock and world map with extra features for amateur radio (1600x960 version)
 	url = https://clearskyinstitute.com/ham/HamClock
 	arch = any
@@ -19,9 +19,9 @@ pkgbase = hamclock-big
 	replaces = hamclock-huge
 	maintainer = Roy Williams <fang64@gmail.com>
 	repology = project: hamclock-big
-	source = https://github.com/fang64/hamclock/archive/refs/tags/v4.21.tar.gz
+	source = https://github.com/fang64/hamclock/archive/refs/tags/v4.22.tar.gz
 	source = hamclock.desktop
-	sha256sums = 0349f395e3b889280dc30bf5d285b168b10f65459de08c0aab06882e76b1144b
+	sha256sums = 3d577561eaa716ebd1b941e3e6abb4763c9a7f68c5f8917b8adb8cf7dd74fa06
 	sha256sums = df56e16e9bfab4a6259fd8e9fdffbe8f8d24ff395d2d27434dfd4bfe4adfa85d
 
 pkgname = hamclock-big

--- a/packages/hamclock-big/hamclock-big.pacscript
+++ b/packages/hamclock-big/hamclock-big.pacscript
@@ -1,6 +1,6 @@
 pkgname="hamclock-big"
 arch=("any")
-pkgver="4.21"
+pkgver="4.22"
 source=(
   "https://github.com/fang64/hamclock/archive/refs/tags/v${pkgver}.tar.gz"
   "hamclock.desktop"
@@ -11,7 +11,7 @@ breaks=("hamclock" "hamclock-bigger" "hamclock-huge")
 replaces=("hamclock-big" "${breaks[@]}")
 pkgdesc="Clock and world map with extra features for amateur radio (1600x960 version)"
 sha256sums=(
-  "0349f395e3b889280dc30bf5d285b168b10f65459de08c0aab06882e76b1144b"
+  "3d577561eaa716ebd1b941e3e6abb4763c9a7f68c5f8917b8adb8cf7dd74fa06"
   "df56e16e9bfab4a6259fd8e9fdffbe8f8d24ff395d2d27434dfd4bfe4adfa85d"
 )
 maintainer=("Roy Williams <fang64@gmail.com>")
@@ -24,6 +24,10 @@ prepare() {
 
   # Set NO_UPGRADE definition this will disable updates
   sed -i '18 i CXXFLAGS += -DNO_UPGRADE' Makefile
+
+  # Change default backend server to hamclock.com instead of clearskyinstitute.com
+  # Elwood Downey has passed away and the service is going to be shutdown in June 2026.
+  sed -i 's/clearskyinstitute.com/hamclock.com/g' wifi.cpp
 }
 
 build() {

--- a/packages/hamclock-bigger/.SRCINFO
+++ b/packages/hamclock-bigger/.SRCINFO
@@ -1,5 +1,5 @@
 pkgbase = hamclock-bigger
-	pkgver = 4.21
+	pkgver = 4.22
 	pkgdesc = Clock and world map with extra features for amateur radio (2400x1440 version)
 	url = https://clearskyinstitute.com/ham/HamClock
 	arch = any
@@ -19,9 +19,9 @@ pkgbase = hamclock-bigger
 	replaces = hamclock-huge
 	maintainer = Roy Williams <fang64@gmail.com>
 	repology = project: hamclock-bigger
-	source = https://github.com/fang64/hamclock/archive/refs/tags/v4.21.tar.gz
+	source = https://github.com/fang64/hamclock/archive/refs/tags/v4.22.tar.gz
 	source = hamclock.desktop
-	sha256sums = 0349f395e3b889280dc30bf5d285b168b10f65459de08c0aab06882e76b1144b
+	sha256sums = 3d577561eaa716ebd1b941e3e6abb4763c9a7f68c5f8917b8adb8cf7dd74fa06
 	sha256sums = df56e16e9bfab4a6259fd8e9fdffbe8f8d24ff395d2d27434dfd4bfe4adfa85d
 
 pkgname = hamclock-bigger

--- a/packages/hamclock-bigger/hamclock-bigger.pacscript
+++ b/packages/hamclock-bigger/hamclock-bigger.pacscript
@@ -1,6 +1,6 @@
 pkgname="hamclock-bigger"
 arch=("any")
-pkgver="4.21"
+pkgver="4.22"
 source=(
   "https://github.com/fang64/hamclock/archive/refs/tags/v${pkgver}.tar.gz"
   "hamclock.desktop"
@@ -11,7 +11,7 @@ breaks=("hamclock" "hamclock-big" "hamclock-huge")
 replaces=("hamclock-bigger" "${breaks[@]}")
 pkgdesc="Clock and world map with extra features for amateur radio (2400x1440 version)"
 sha256sums=(
-  "0349f395e3b889280dc30bf5d285b168b10f65459de08c0aab06882e76b1144b"
+  "3d577561eaa716ebd1b941e3e6abb4763c9a7f68c5f8917b8adb8cf7dd74fa06"
   "df56e16e9bfab4a6259fd8e9fdffbe8f8d24ff395d2d27434dfd4bfe4adfa85d"
 )
 maintainer=("Roy Williams <fang64@gmail.com>")
@@ -24,6 +24,10 @@ prepare() {
 
   # Set NO_UPGRADE definition this will disable updates
   sed -i '18 i CXXFLAGS += -DNO_UPGRADE' Makefile
+
+  # Change default backend server to hamclock.com instead of clearskyinstitute.com
+  # Elwood Downey has passed away and the service is going to be shutdown in June 2026.
+  sed -i 's/clearskyinstitute.com/hamclock.com/g' wifi.cpp
 }
 
 build() {

--- a/packages/hamclock-huge/.SRCINFO
+++ b/packages/hamclock-huge/.SRCINFO
@@ -1,5 +1,5 @@
 pkgbase = hamclock-huge
-	pkgver = 4.21
+	pkgver = 4.22
 	pkgdesc = Clock and world map with extra features for amateur radio (3200x1920 version)
 	url = https://clearskyinstitute.com/ham/HamClock
 	arch = any
@@ -19,9 +19,9 @@ pkgbase = hamclock-huge
 	replaces = hamclock-bigger
 	maintainer = Roy Williams <fang64@gmail.com>
 	repology = project: hamclock-huge
-	source = https://github.com/fang64/hamclock/archive/refs/tags/v4.21.tar.gz
+	source = https://github.com/fang64/hamclock/archive/refs/tags/v4.22.tar.gz
 	source = hamclock.desktop
-	sha256sums = 0349f395e3b889280dc30bf5d285b168b10f65459de08c0aab06882e76b1144b
+	sha256sums = 3d577561eaa716ebd1b941e3e6abb4763c9a7f68c5f8917b8adb8cf7dd74fa06
 	sha256sums = df56e16e9bfab4a6259fd8e9fdffbe8f8d24ff395d2d27434dfd4bfe4adfa85d
 
 pkgname = hamclock-huge

--- a/packages/hamclock-huge/hamclock-huge.pacscript
+++ b/packages/hamclock-huge/hamclock-huge.pacscript
@@ -1,6 +1,6 @@
 pkgname="hamclock-huge"
 arch=("any")
-pkgver="4.21"
+pkgver="4.22"
 source=(
   "https://github.com/fang64/hamclock/archive/refs/tags/v${pkgver}.tar.gz"
   "hamclock.desktop"
@@ -11,7 +11,7 @@ breaks=("hamclock" "hamclock-big" "hamclock-bigger")
 replaces=("hamclock-huge" "${breaks[@]}")
 pkgdesc="Clock and world map with extra features for amateur radio (3200x1920 version)"
 sha256sums=(
-  "0349f395e3b889280dc30bf5d285b168b10f65459de08c0aab06882e76b1144b"
+  "3d577561eaa716ebd1b941e3e6abb4763c9a7f68c5f8917b8adb8cf7dd74fa06"
   "df56e16e9bfab4a6259fd8e9fdffbe8f8d24ff395d2d27434dfd4bfe4adfa85d"
 )
 maintainer=("Roy Williams <fang64@gmail.com>")
@@ -24,6 +24,10 @@ prepare() {
 
   # Set NO_UPGRADE definition this will disable updates
   sed -i '18 i CXXFLAGS += -DNO_UPGRADE' Makefile
+
+  # Change default backend server to hamclock.com instead of clearskyinstitute.com
+  # Elwood Downey has passed away and the service is going to be shutdown in June 2026.
+  sed -i 's/clearskyinstitute.com/hamclock.com/g' wifi.cpp
 }
 
 build() {

--- a/packages/hamclock/.SRCINFO
+++ b/packages/hamclock/.SRCINFO
@@ -1,5 +1,5 @@
 pkgbase = hamclock
-	pkgver = 4.21
+	pkgver = 4.22
 	pkgdesc = Clock and world map with extra features for amateur radio (800x480 version)
 	url = https://clearskyinstitute.com/ham/HamClock
 	arch = any
@@ -19,9 +19,9 @@ pkgbase = hamclock
 	replaces = hamclock-huge
 	maintainer = Roy Williams <fang64@gmail.com>
 	repology = project: hamclock
-	source = https://github.com/fang64/hamclock/archive/refs/tags/v4.21.tar.gz
+	source = https://github.com/fang64/hamclock/archive/refs/tags/v4.22.tar.gz
 	source = hamclock.desktop
-	sha256sums = 0349f395e3b889280dc30bf5d285b168b10f65459de08c0aab06882e76b1144b
+	sha256sums = 3d577561eaa716ebd1b941e3e6abb4763c9a7f68c5f8917b8adb8cf7dd74fa06
 	sha256sums = df56e16e9bfab4a6259fd8e9fdffbe8f8d24ff395d2d27434dfd4bfe4adfa85d
 
 pkgname = hamclock

--- a/packages/hamclock/hamclock.pacscript
+++ b/packages/hamclock/hamclock.pacscript
@@ -1,6 +1,6 @@
 pkgname="hamclock"
 arch=("any")
-pkgver="4.21"
+pkgver="4.22"
 source=(
   "https://github.com/fang64/hamclock/archive/refs/tags/v${pkgver}.tar.gz"
   "hamclock.desktop"
@@ -11,7 +11,7 @@ breaks=("hamclock-big" "hamclock-bigger" "hamclock-huge")
 replaces=("hamclock" "${breaks[@]}")
 pkgdesc="Clock and world map with extra features for amateur radio (800x480 version)"
 sha256sums=(
-  "0349f395e3b889280dc30bf5d285b168b10f65459de08c0aab06882e76b1144b"
+  "3d577561eaa716ebd1b941e3e6abb4763c9a7f68c5f8917b8adb8cf7dd74fa06"
   "df56e16e9bfab4a6259fd8e9fdffbe8f8d24ff395d2d27434dfd4bfe4adfa85d"
 )
 maintainer=("Roy Williams <fang64@gmail.com>")
@@ -25,6 +25,9 @@ prepare() {
   # Set NO_UPGRADE definition this will disable updates
   sed -i '18 i CXXFLAGS += -DNO_UPGRADE' Makefile
 
+  # Change default backend server to hamclock.com instead of clearskyinstitute.com
+  # Elwood Downey has passed away and the service is going to be shutdown in June 2026.
+  sed -i 's/clearskyinstitute.com/hamclock.com/g' wifi.cpp
 }
 
 build() {

--- a/srclist
+++ b/srclist
@@ -5116,7 +5116,7 @@ pkgbase = hakuneko-deb
 pkgname = hakuneko-deb
 ---
 pkgbase = hamclock-big
-	pkgver = 4.21
+	pkgver = 4.22
 	pkgdesc = Clock and world map with extra features for amateur radio (1600x960 version)
 	url = https://clearskyinstitute.com/ham/HamClock
 	arch = any
@@ -5136,15 +5136,15 @@ pkgbase = hamclock-big
 	replaces = hamclock-huge
 	maintainer = Roy Williams <fang64@gmail.com>
 	repology = project: hamclock-big
-	source = https://github.com/fang64/hamclock/archive/refs/tags/v4.21.tar.gz
+	source = https://github.com/fang64/hamclock/archive/refs/tags/v4.22.tar.gz
 	source = hamclock.desktop
-	sha256sums = 0349f395e3b889280dc30bf5d285b168b10f65459de08c0aab06882e76b1144b
+	sha256sums = 3d577561eaa716ebd1b941e3e6abb4763c9a7f68c5f8917b8adb8cf7dd74fa06
 	sha256sums = df56e16e9bfab4a6259fd8e9fdffbe8f8d24ff395d2d27434dfd4bfe4adfa85d
 
 pkgname = hamclock-big
 ---
 pkgbase = hamclock-bigger
-	pkgver = 4.21
+	pkgver = 4.22
 	pkgdesc = Clock and world map with extra features for amateur radio (2400x1440 version)
 	url = https://clearskyinstitute.com/ham/HamClock
 	arch = any
@@ -5164,15 +5164,15 @@ pkgbase = hamclock-bigger
 	replaces = hamclock-huge
 	maintainer = Roy Williams <fang64@gmail.com>
 	repology = project: hamclock-bigger
-	source = https://github.com/fang64/hamclock/archive/refs/tags/v4.21.tar.gz
+	source = https://github.com/fang64/hamclock/archive/refs/tags/v4.22.tar.gz
 	source = hamclock.desktop
-	sha256sums = 0349f395e3b889280dc30bf5d285b168b10f65459de08c0aab06882e76b1144b
+	sha256sums = 3d577561eaa716ebd1b941e3e6abb4763c9a7f68c5f8917b8adb8cf7dd74fa06
 	sha256sums = df56e16e9bfab4a6259fd8e9fdffbe8f8d24ff395d2d27434dfd4bfe4adfa85d
 
 pkgname = hamclock-bigger
 ---
 pkgbase = hamclock-huge
-	pkgver = 4.21
+	pkgver = 4.22
 	pkgdesc = Clock and world map with extra features for amateur radio (3200x1920 version)
 	url = https://clearskyinstitute.com/ham/HamClock
 	arch = any
@@ -5192,15 +5192,15 @@ pkgbase = hamclock-huge
 	replaces = hamclock-bigger
 	maintainer = Roy Williams <fang64@gmail.com>
 	repology = project: hamclock-huge
-	source = https://github.com/fang64/hamclock/archive/refs/tags/v4.21.tar.gz
+	source = https://github.com/fang64/hamclock/archive/refs/tags/v4.22.tar.gz
 	source = hamclock.desktop
-	sha256sums = 0349f395e3b889280dc30bf5d285b168b10f65459de08c0aab06882e76b1144b
+	sha256sums = 3d577561eaa716ebd1b941e3e6abb4763c9a7f68c5f8917b8adb8cf7dd74fa06
 	sha256sums = df56e16e9bfab4a6259fd8e9fdffbe8f8d24ff395d2d27434dfd4bfe4adfa85d
 
 pkgname = hamclock-huge
 ---
 pkgbase = hamclock
-	pkgver = 4.21
+	pkgver = 4.22
 	pkgdesc = Clock and world map with extra features for amateur radio (800x480 version)
 	url = https://clearskyinstitute.com/ham/HamClock
 	arch = any
@@ -5220,9 +5220,9 @@ pkgbase = hamclock
 	replaces = hamclock-huge
 	maintainer = Roy Williams <fang64@gmail.com>
 	repology = project: hamclock
-	source = https://github.com/fang64/hamclock/archive/refs/tags/v4.21.tar.gz
+	source = https://github.com/fang64/hamclock/archive/refs/tags/v4.22.tar.gz
 	source = hamclock.desktop
-	sha256sums = 0349f395e3b889280dc30bf5d285b168b10f65459de08c0aab06882e76b1144b
+	sha256sums = 3d577561eaa716ebd1b941e3e6abb4763c9a7f68c5f8917b8adb8cf7dd74fa06
 	sha256sums = df56e16e9bfab4a6259fd8e9fdffbe8f8d24ff395d2d27434dfd4bfe4adfa85d
 
 pkgname = hamclock


### PR DESCRIPTION
I meant to do this update awhile ago, but it seems it wasn't warranted until a decision was made. We might see one more update from the "Open HamClock Backend" folks over at [OHB](https://ohb.works) given the circumstances at least the software remains functional and potentially will be maintained. 

Elwood Downey has passed away and [clearskyinstitute.com](clearskyinstitute.com) will be shutdown June 2026. This required modifying the backend to use [hamclock.com](hamclock.com) as a data source.