### PR TITLE
fix(godot-mono-bin): change icon name in the desktop file

### DIFF
--- a/packages/godot-mono-bin/desktop.patch
+++ b/packages/godot-mono-bin/desktop.patch
@@ -8,6 +8,7 @@ index 6483f51..bef57a1 100644
  Comment[zh_CN]=多平台 2D 和 3D 游戏引擎，带有功能丰富的编辑器
 -Exec=godot %f
 +Exec=godot-mono %f
- Icon=godot
+-Icon=godot
++Icon=godot-mono
  Terminal=false
  PrefersNonDefaultGPU=true


### PR DESCRIPTION
The desktop file is looking for godot.svg, which doesn't exist when installing ``godot-mono-bin``