### PR TITLE
add: `scx-scheds`

### DIFF
--- a/packagelist
+++ b/packagelist
@@ -722,6 +722,7 @@ sbt-deb
 scangearmp2-sane-git
 schildichat-deb
 scrcpy
+scx-scheds
 sed
 setconf
 shell-color-scripts

--- a/packages/scx-scheds/.SRCINFO
+++ b/packages/scx-scheds/.SRCINFO
@@ -1,0 +1,40 @@
+pkgbase = scx-scheds
+	pkgver = 1.1.0
+	pkgdesc = sched_ext schedulers and tools
+	url = https://github.com/sched-ext/scx
+	arch = x86_64
+	depends = bash
+	depends = bpftool
+	depends = libgcc-s1
+	depends = libseccomp2
+	depends = libbpf1>=1.3
+	depends = libelf1t64
+	depends = libprotobuf32t64
+	depends = zlib1g
+	makedepends = cargo>=1.82
+	makedepends = build-essential
+	makedepends = cmake
+	makedepends = rustc
+	makedepends = clang
+	makedepends = llvm
+	makedepends = pkg-config
+	makedepends = libelf-dev
+	makedepends = protobuf-compiler
+	makedepends = libseccomp-dev
+	makedepends = libbpf-dev
+	makedepends = pahole
+	conflicts = scx-scheds
+	provides = scx-scheds
+	recommends = scx-loader
+	incompatible = debian:bullseye
+	incompatible = debian:bookworm
+	incompatible = ubuntu:jammy
+	incompatible = ubuntu:noble
+	backup = etc/default/scx
+	license = GPL-2.0-only
+	maintainer = pejuton <pejuton@proton.me>
+	repology = project: scx-scheds
+	source = git+https://github.com/sched-ext/scx#commit=c505008f6cf917b86950734eb869048e1a462fa0
+	sha256sums = SKIP
+
+pkgname = scx-scheds

--- a/packages/scx-scheds/.SRCINFO
+++ b/packages/scx-scheds/.SRCINFO
@@ -11,10 +11,8 @@ pkgbase = scx-scheds
 	depends = libelf1t64
 	depends = libprotobuf32t64
 	depends = zlib1g
-	makedepends = cargo>=1.82
+	makedepends = cargo>=1.88 | rustup
 	makedepends = build-essential
-	makedepends = cmake
-	makedepends = rustc
 	makedepends = clang
 	makedepends = llvm
 	makedepends = pkg-config
@@ -22,12 +20,14 @@ pkgbase = scx-scheds
 	makedepends = protobuf-compiler
 	makedepends = libseccomp-dev
 	makedepends = libbpf-dev
+	makedepends = libzstd-dev
 	makedepends = pahole
 	conflicts = scx-scheds
 	provides = scx-scheds
 	recommends = scx-loader
 	incompatible = debian:bullseye
 	incompatible = debian:bookworm
+	incompatible = debian:trixie
 	incompatible = ubuntu:jammy
 	incompatible = ubuntu:noble
 	backup = etc/default/scx

--- a/packages/scx-scheds/scx-scheds.pacscript
+++ b/packages/scx-scheds/scx-scheds.pacscript
@@ -1,0 +1,105 @@
+pkgname="scx-scheds"
+pkgdesc="sched_ext schedulers and tools"
+repology=("project: scx-scheds")
+arch=('x86_64')
+pkgver="1.1.0"
+url='https://github.com/sched-ext/scx'
+license=('GPL-2.0-only')
+_gitname='scx'
+_commit='c505008f6cf917b86950734eb869048e1a462fa0'
+source=("git+https://github.com/sched-ext/${_gitname}#commit=${_commit}")
+sha256sums=('SKIP')
+provides=("${pkgname}")
+conflicts=("${pkgname}")
+limit_kver=">=6.12"
+incompatible=("debian:bullseye" "debian:bookworm" "ubuntu:jammy" "ubuntu:noble")
+depends=(
+  "bash"
+  "bpftool"
+  "libgcc-s1"
+  "libseccomp2"
+  "libbpf1>=1.3"
+  "libelf1t64"
+  "libprotobuf32t64"
+  "zlib1g"
+)
+makedepends=(
+  "cargo>=1.82"
+  "build-essential"
+  "cmake"
+  "rustc"
+  "clang"
+  "llvm"
+  "pkg-config"
+  "libelf-dev"
+  "protobuf-compiler"
+  "libseccomp-dev"
+  "libbpf-dev"
+  "pahole"
+)
+recommends=("scx-loader")
+backup=('etc/default/scx')
+maintainer=("pejuton <pejuton@proton.me>")
+external_connection=true
+
+prepare() {
+  cd "${_gitname}"
+
+  export CARGO_HOME="${srcdir}/cargo-home"
+
+  cargo fetch --locked --target "${AARCH}-unknown-linux-gnu"
+}
+
+build() {
+  cd "${_gitname}"
+
+  export CARGO_HOME="${srcdir}/cargo-home"
+  export CARGO_TARGET_DIR=target
+
+  cargo build \
+    --release \
+    --frozen \
+    --all-features \
+    --workspace \
+    --jobs "${NCPU}" \
+    --exclude scx_mitosis \
+    --exclude scx_rlfifo \
+    --exclude scx_wd40 \
+    --exclude scxcash \
+    --exclude xtask \
+    --exclude vmlinux_docify \
+    --exclude scx_arena_selftests \
+    --exclude scx_bpf_unittests
+}
+
+package() {
+  cd "${_gitname}"
+
+  # Install all built executables (skip .so and .d files)
+  find target/release \
+    -maxdepth 1 -type f -executable ! -name '*.so' \
+    -exec install -vDm755 -t "${pkgdir}/usr/bin/" {} +
+
+  # Systemd service
+  install -vDm644 services/scx.service -t "${pkgdir}/usr/lib/systemd/system"
+  install -vDm644 services/scx -t "${pkgdir}/etc/default"
+}
+
+pre_remove() {
+  # Stop systemd service if started
+  if (systemctl -q is-active scx.service); then
+    systemctl stop -v scx.service
+    fancy_message warn "Stopped 'scx.service'. If package upgrade or reinstall, start it again after install."
+  fi
+
+  # Disable systemd service if enabled
+  if (systemctl -q is-enabled scx.service); then
+    systemctl disable -v scx.service
+    fancy_message warn "Disabled 'scx.service'. If package upgrade or reinstall, enable it again after install."
+  fi
+}
+
+post_install() {
+  fancy_message info "Start/enable systemd service 'scx.service' or use 'scx-loader'."
+  fancy_message info "scx.service configuration in '/etc/default/scx'."
+}

--- a/packages/scx-scheds/scx-scheds.pacscript
+++ b/packages/scx-scheds/scx-scheds.pacscript
@@ -12,7 +12,7 @@ sha256sums=('SKIP')
 provides=("${pkgname}")
 conflicts=("${pkgname}")
 limit_kver=">=6.12"
-incompatible=("debian:bullseye" "debian:bookworm" "ubuntu:jammy" "ubuntu:noble")
+incompatible=("debian:bullseye" "debian:bookworm" "debian:trixie" "ubuntu:jammy" "ubuntu:noble")
 depends=(
   "bash"
   "bpftool"
@@ -24,10 +24,8 @@ depends=(
   "zlib1g"
 )
 makedepends=(
-  "cargo>=1.82"
+  "cargo>=1.88 | rustup"
   "build-essential"
-  "cmake"
-  "rustc"
   "clang"
   "llvm"
   "pkg-config"
@@ -35,6 +33,7 @@ makedepends=(
   "protobuf-compiler"
   "libseccomp-dev"
   "libbpf-dev"
+  "libzstd-dev"
   "pahole"
 )
 recommends=("scx-loader")
@@ -46,6 +45,7 @@ prepare() {
   cd "${_gitname}"
 
   export CARGO_HOME="${srcdir}/cargo-home"
+  export RUSTUP_TOOLCHAIN=stable
 
   cargo fetch --locked --target "${AARCH}-unknown-linux-gnu"
 }
@@ -55,6 +55,7 @@ build() {
 
   export CARGO_HOME="${srcdir}/cargo-home"
   export CARGO_TARGET_DIR=target
+  export RUSTUP_TOOLCHAIN=stable
 
   cargo build \
     --release \
@@ -86,16 +87,15 @@ package() {
 }
 
 pre_remove() {
-  # Stop systemd service if started
-  if (systemctl -q is-active scx.service); then
-    systemctl stop -v scx.service
-    fancy_message warn "Stopped 'scx.service'. If package upgrade or reinstall, start it again after install."
-  fi
-
-  # Disable systemd service if enabled
-  if (systemctl -q is-enabled scx.service); then
-    systemctl disable -v scx.service
-    fancy_message warn "Disabled 'scx.service'. If package upgrade or reinstall, enable it again after install."
+  if [[ -x "/usr/bin/systemctl" ]]; then
+    if systemctl -q is-active scx.service 2> /dev/null; then
+      systemctl stop scx.service || true
+      fancy_message warn "Stopped 'scx.service'. If package upgrade or reinstall, start it again after install."
+    fi
+    if systemctl -q is-enabled scx.service 2> /dev/null; then
+      systemctl disable scx.service || true
+      fancy_message warn "Disabled 'scx.service'. If package upgrade or reinstall, enable it again after install."
+    fi
   fi
 }
 

--- a/srclist
+++ b/srclist
@@ -14176,6 +14176,47 @@ pkgbase = scrcpy
 
 pkgname = scrcpy
 ---
+pkgbase = scx-scheds
+	pkgver = 1.1.0
+	pkgdesc = sched_ext schedulers and tools
+	url = https://github.com/sched-ext/scx
+	arch = x86_64
+	depends = bash
+	depends = bpftool
+	depends = libgcc-s1
+	depends = libseccomp2
+	depends = libbpf1>=1.3
+	depends = libelf1t64
+	depends = libprotobuf32t64
+	depends = zlib1g
+	makedepends = cargo>=1.82
+	makedepends = build-essential
+	makedepends = cmake
+	makedepends = rustc
+	makedepends = clang
+	makedepends = llvm
+	makedepends = pkg-config
+	makedepends = libelf-dev
+	makedepends = protobuf-compiler
+	makedepends = libseccomp-dev
+	makedepends = libbpf-dev
+	makedepends = pahole
+	conflicts = scx-scheds
+	provides = scx-scheds
+	recommends = scx-loader
+	incompatible = debian:bullseye
+	incompatible = debian:bookworm
+	incompatible = ubuntu:jammy
+	incompatible = ubuntu:noble
+	backup = etc/default/scx
+	license = GPL-2.0-only
+	maintainer = pejuton <pejuton@proton.me>
+	repology = project: scx-scheds
+	source = git+https://github.com/sched-ext/scx#commit=c505008f6cf917b86950734eb869048e1a462fa0
+	sha256sums = SKIP
+
+pkgname = scx-scheds
+---
 pkgbase = sed
 	pkgver = 4.9
 	pkgdesc = sed (stream editor) is a non-interactive command-line text editor.

--- a/srclist
+++ b/srclist
@@ -14189,10 +14189,8 @@ pkgbase = scx-scheds
 	depends = libelf1t64
 	depends = libprotobuf32t64
 	depends = zlib1g
-	makedepends = cargo>=1.82
+	makedepends = cargo>=1.88 | rustup
 	makedepends = build-essential
-	makedepends = cmake
-	makedepends = rustc
 	makedepends = clang
 	makedepends = llvm
 	makedepends = pkg-config
@@ -14200,12 +14198,14 @@ pkgbase = scx-scheds
 	makedepends = protobuf-compiler
 	makedepends = libseccomp-dev
 	makedepends = libbpf-dev
+	makedepends = libzstd-dev
 	makedepends = pahole
 	conflicts = scx-scheds
 	provides = scx-scheds
 	recommends = scx-loader
 	incompatible = debian:bullseye
 	incompatible = debian:bookworm
+	incompatible = debian:trixie
 	incompatible = ubuntu:jammy
 	incompatible = ubuntu:noble
 	backup = etc/default/scx


### PR DESCRIPTION
https://github.com/sched-ext/scx

Pacscript for sched_ext schedulers and tools. Requires kernel 6.12 or later. Install instructions for Ubuntu recommends upgrading to 25.10. I have only tested this on Kubuntu 26.04.

Links:
- Build instructions: https://github.com/sched-ext/scx/blob/main/CARGO_BUILD.md
- Install instructions for Ubuntu: https://github.com/sched-ext/scx/blob/main/INSTALL.md#ubuntu
- Systemd service instructions: https://github.com/sched-ext/scx/blob/main/services/README.md
- PKGBUILD: https://gitlab.archlinux.org/archlinux/packaging/packages/scx-scheds/-/blob/main/PKGBUILD?ref_type=heads
- scx-loader tool: https://github.com/sched-ext/scx-loader