### PR TITLE
fix(canon-pixma-mg3000-complete): ppd file is not present and dependcy not found

### DIFF
--- a/packages/canon-pixma-mg3000-complete-deb/.SRCINFO
+++ b/packages/canon-pixma-mg3000-complete-deb/.SRCINFO
@@ -7,13 +7,13 @@ pkgbase = canon-pixma-mg3000-complete-deb
 	arch = i386
 	depends = libc6>=2.7
 	depends = libgcc-s1 | libgcc1
-	depends = libcups2
+	depends = libcups2t64 | libcups2>=1.2.1
 	depends = libstdc++6
 	depends = binutils
 	depends = cups
 	depends = libxml2>=2.7.4 | libxml2-16
-	depends = libcupsimage2
-	depends = libusb-1.0-0
+	depends = libcupsimage2t64 | libcupsimage2
+	depends = libusb-1.0-0>=1.0.6
 	depends = libpopt0
 	depends = libtiff6 | libtiff5
 	optdepends = scangearmp2-deb: Scanner driver for Canon

--- a/packages/canon-pixma-mg3000-complete-deb/.SRCINFO
+++ b/packages/canon-pixma-mg3000-complete-deb/.SRCINFO
@@ -6,16 +6,16 @@ pkgbase = canon-pixma-mg3000-complete-deb
 	arch = amd64
 	arch = i386
 	depends = libc6>=2.7
-	depends = libgcc1
+	depends = libgcc-s1 | libgcc1
 	depends = libcups2
 	depends = libstdc++6
 	depends = binutils
 	depends = cups
-	depends = libxml2>=2.7.4
-	depends = libcupsimage2>=1.4.0
-	depends = libusb-0.1-4
+	depends = libxml2>=2.7.4 | libxml2-16
+	depends = libcupsimage2
+	depends = libusb-1.0-0
 	depends = libpopt0
-	depends = libtiff6
+	depends = libtiff6 | libtiff5
 	optdepends = scangearmp2-deb: Scanner driver for Canon
 	replaces = cnijfilter2
 	maintainer = aKqir24 <aKqir24@github.com>

--- a/packages/canon-pixma-mg3000-complete-deb/.SRCINFO
+++ b/packages/canon-pixma-mg3000-complete-deb/.SRCINFO
@@ -1,4 +1,4 @@
-pkgbase = canon-pixma-mg3000-complete-deb
+pkgbase = canon-pixma-mg3000-deb
 	gives = cnijfilter2
 	pkgver = 5.40
 	pkgdesc = Complete stand alone driver set printing for Canon Pixma MG3000 series
@@ -20,6 +20,8 @@ pkgbase = canon-pixma-mg3000-complete-deb
 	replaces = cnijfilter2
 	maintainer = aKqir24 <aKqir24@github.com>
 	source_amd64 = https://files.catbox.moe/mmxzt2.deb
+	sha256sums_amd64 = b98281e43d3f28bc21c6d76de5fa3a6fce3430c79fc1fde6835574f2748085a8
 	source_i386 = https://files.catbox.moe/8tiosl.deb
+	sha256sums_i386 = ea72ad1a1ef1cb91144e40b8fff0dd9ca9bcf61d893b8bec15dfbb4d8545fe80
 
-pkgname = canon-pixma-mg3000-complete-deb
+pkgname = canon-pixma-mg3000-deb

--- a/packages/canon-pixma-mg3000-complete-deb/canon-pixma-mg3000-complete-deb.pacscript
+++ b/packages/canon-pixma-mg3000-complete-deb/canon-pixma-mg3000-complete-deb.pacscript
@@ -7,16 +7,16 @@ url='https://www.canon-europe.com/support/consumer_products/products/fax__multif
 
 depends=(
   "libc6>=2.7"
-  "libgcc1"
-  "libcups2"
+  "libgcc-s1 | libgcc1"
+  "libcups2t64 | libcups2>=1.2.1"
   "libstdc++6"
   "binutils"
   "cups"
-  "libxml2>=2.7.4"
-  "libcupsimage2>=1.4.0"
-  "libusb-0.1-4"
+  "libxml2>=2.7.4 | libxml2-16"
+  "libcupsimage2t64 | libcupsimage2"
+  "libusb-1.0-0>=1.0.6"
   "libpopt0"
-  "libtiff6"
+  "libtiff6 | libtiff5"
 )
 optdepends=("scangearmp2-deb: Scanner driver for Canon")
 replaces=("${gives}")
@@ -24,20 +24,13 @@ maintainer=("aKqir24 <aKqir24@github.com>")
 source_amd64=("https://files.catbox.moe/mmxzt2.deb")
 source_i386=("https://files.catbox.moe/8tiosl.deb")
 
-package() {
+post_install() {
+  # Since pacstall handles packaging in deb files I need to get the PPD this way
+  cd "${pkgdir}"
   _ppdFile="canonmg3000.ppd"
+  curl -L -o "usr/share/ppd/${_ppdFile}" https://gist.githubusercontent.com/aKqir24/8215d85c5788fc969bfa3b7d88f52699/raw/b1325c2889b1bb2905e48d1b3c18738b8fc49a1d/"${_ppdFile}"
 
   install -Dm644 /usr/share/ppd/"${_ppdFile}" \
     "${pkgdir}/usr/share/cups/model/${_ppdFile}"
-
-  rm -rf usr/share/ppd
-  cp -a usr "${pkgdir}/"
-
-  find usr/share/doc -name 'LICENSE*' -exec install -Dm644 {} \
-    "${pkgdir}/usr/share/licenses/${pkgname}/$(basename {})" \;
-}
-
-post_install() {
-  fancy_message info "To make this driver work, make sure the cups service is running.\n
-  If not then, run sudo systemctl enable cups.service"
+  fancy_message info "To make this driver work, make sure the cups service is running. If not then, run sudo systemctl enable cups.service"
 }

--- a/packages/canon-pixma-mg3000-complete-deb/canon-pixma-mg3000-complete-deb.pacscript
+++ b/packages/canon-pixma-mg3000-complete-deb/canon-pixma-mg3000-complete-deb.pacscript
@@ -1,4 +1,4 @@
-pkgname="canon-pixma-mg3000-complete-deb"
+pkgname="canon-pixma-mg3000-deb"
 pkgver="5.40"
 gives="cnijfilter2"
 pkgdesc="Complete stand alone driver set printing for Canon Pixma MG3000 series"
@@ -23,14 +23,13 @@ replaces=("${gives}")
 maintainer=("aKqir24 <aKqir24@github.com>")
 source_amd64=("https://files.catbox.moe/mmxzt2.deb")
 source_i386=("https://files.catbox.moe/8tiosl.deb")
+sha256sums_amd64=("b98281e43d3f28bc21c6d76de5fa3a6fce3430c79fc1fde6835574f2748085a8")
+sha256sums_i386=("ea72ad1a1ef1cb91144e40b8fff0dd9ca9bcf61d893b8bec15dfbb4d8545fe80")
 
 post_install() {
-  # Since pacstall handles packaging in deb files I need to get the PPD this way
-  cd "${pkgdir}"
   _ppdFile="canonmg3000.ppd"
-  curl -L -o "usr/share/ppd/${_ppdFile}" https://gist.githubusercontent.com/aKqir24/8215d85c5788fc969bfa3b7d88f52699/raw/b1325c2889b1bb2905e48d1b3c18738b8fc49a1d/"${_ppdFile}"
-
-  install -Dm644 /usr/share/ppd/"${_ppdFile}" \
-    "${pkgdir}/usr/share/cups/model/${_ppdFile}"
+  mkdir -p "/usr/share/cups/model"
+  curl -L -o "/usr/share/cups/model/${_ppdFile}" \
+    "https://gist.githubusercontent.com/aKqir24/8215d85c5788fc969bfa3b7d88f52699/raw/b1325c2889b1bb2905e48d1b3c18738b8fc49a1d/${_ppdFile}"
   fancy_message info "To make this driver work, make sure the cups service is running. If not then, run sudo systemctl enable cups.service"
 }

--- a/srclist
+++ b/srclist
@@ -1409,13 +1409,13 @@ pkgbase = canon-pixma-mg3000-complete-deb
 	arch = i386
 	depends = libc6>=2.7
 	depends = libgcc-s1 | libgcc1
-	depends = libcups2
+	depends = libcups2t64 | libcups2>=1.2.1
 	depends = libstdc++6
 	depends = binutils
 	depends = cups
 	depends = libxml2>=2.7.4 | libxml2-16
-	depends = libcupsimage2
-	depends = libusb-1.0-0
+	depends = libcupsimage2t64 | libcupsimage2
+	depends = libusb-1.0-0>=1.0.6
 	depends = libpopt0
 	depends = libtiff6 | libtiff5
 	optdepends = scangearmp2-deb: Scanner driver for Canon

--- a/srclist
+++ b/srclist
@@ -1408,16 +1408,16 @@ pkgbase = canon-pixma-mg3000-complete-deb
 	arch = amd64
 	arch = i386
 	depends = libc6>=2.7
-	depends = libgcc1
+	depends = libgcc-s1 | libgcc1
 	depends = libcups2
 	depends = libstdc++6
 	depends = binutils
 	depends = cups
-	depends = libxml2>=2.7.4
-	depends = libcupsimage2>=1.4.0
-	depends = libusb-0.1-4
+	depends = libxml2>=2.7.4 | libxml2-16
+	depends = libcupsimage2
+	depends = libusb-1.0-0
 	depends = libpopt0
-	depends = libtiff6
+	depends = libtiff6 | libtiff5
 	optdepends = scangearmp2-deb: Scanner driver for Canon
 	replaces = cnijfilter2
 	maintainer = aKqir24 <aKqir24@github.com>

--- a/srclist
+++ b/srclist
@@ -1400,7 +1400,7 @@ pkgbase = cachyos-ananicy-rules-git
 
 pkgname = cachyos-ananicy-rules-git
 ---
-pkgbase = canon-pixma-mg3000-complete-deb
+pkgbase = canon-pixma-mg3000-deb
 	gives = cnijfilter2
 	pkgver = 5.40
 	pkgdesc = Complete stand alone driver set printing for Canon Pixma MG3000 series
@@ -1422,9 +1422,11 @@ pkgbase = canon-pixma-mg3000-complete-deb
 	replaces = cnijfilter2
 	maintainer = aKqir24 <aKqir24@github.com>
 	source_amd64 = https://files.catbox.moe/mmxzt2.deb
+	sha256sums_amd64 = b98281e43d3f28bc21c6d76de5fa3a6fce3430c79fc1fde6835574f2748085a8
 	source_i386 = https://files.catbox.moe/8tiosl.deb
+	sha256sums_i386 = ea72ad1a1ef1cb91144e40b8fff0dd9ca9bcf61d893b8bec15dfbb4d8545fe80
 
-pkgname = canon-pixma-mg3000-complete-deb
+pkgname = canon-pixma-mg3000-deb
 ---
 pkgbase = cantata
 	gives = cantata


### PR DESCRIPTION
Only managed to make it work on stable ubuntu and debian.

## Progress
- [x] fix ppd file not being installed
- [x] dependcy support for ubuntu 
- [x] small format changes