### PR TITLE
add: `openbangla-keyboard-git`

### DIFF
--- a/packagelist
+++ b/packagelist
@@ -575,6 +575,7 @@ onefetch-bin
 onlyoffice-desktopeditors-deb
 onnxruntime-bin
 onnxruntime-gpu-bin
+openbangla-keyboard-git
 opendoas-git
 openrgb-git
 opensnitch-deb

--- a/packages/openbangla-keyboard-git/openbangla-keyboard-git.pacscript
+++ b/packages/openbangla-keyboard-git/openbangla-keyboard-git.pacscript
@@ -1,0 +1,53 @@
+pkgname="openbangla-keyboard-git"
+gives="openbangla-keyboard"
+pkgdesc="An OpenSource, Unicode compliant Bengali Input Method"
+url="https://github.com/OpenBangla/OpenBangla-Keyboard"
+maintainer=("Niamot <58494481+niam0t@users.noreply.github.com>")
+
+external_connection="true"
+
+arch=("amd64")
+source=("git+https://github.com/OpenBangla/OpenBangla-Keyboard.git")
+repology=("project: ${gives}")
+pkgver="0.0.0"
+
+replaces=("${gives}")
+conflicts=("${gives}")
+
+depends=(
+    "ibus"
+    "libzstd1"
+    "libqt5gui5"
+    "libqt5widgets5"
+    "libqt5network5"
+)
+makedepends=(
+    "cmake"
+    "build-essential"
+    "rustc"
+    "cargo"
+    "libibus-1.0-dev"
+    "qtbase5-dev"
+    "qtbase5-dev-tools"
+    "libzstd-dev"
+)
+
+prepare() {
+    cd "${srcdir}/OpenBangla-Keyboard"
+    git submodule update --init --recursive
+    pkgver="r$(git rev-list --count HEAD).$(git rev-parse --short HEAD)"
+}
+
+build() {
+    cd "${srcdir}/OpenBangla-Keyboard"
+    mkdir -p build && cd build
+    cmake .. \
+        -DCMAKE_INSTALL_PREFIX=/usr \
+        -DCMAKE_BUILD_TYPE=Release
+    make -j"${NCPU}"
+}
+
+package() {
+    cd "${srcdir}/OpenBangla-Keyboard/build"
+    make install DESTDIR="${pkgdir}"
+}

--- a/packages/openbangla-keyboard-git/openbangla-keyboard-git.pacscript
+++ b/packages/openbangla-keyboard-git/openbangla-keyboard-git.pacscript
@@ -15,39 +15,39 @@ replaces=("${gives}")
 conflicts=("${gives}")
 
 depends=(
-    "ibus"
-    "libzstd1"
-    "libqt5gui5"
-    "libqt5widgets5"
-    "libqt5network5"
+  "ibus"
+  "libzstd1"
+  "libqt5gui5"
+  "libqt5widgets5"
+  "libqt5network5"
 )
 makedepends=(
-    "cmake"
-    "build-essential"
-    "rustc"
-    "cargo"
-    "libibus-1.0-dev"
-    "qtbase5-dev"
-    "qtbase5-dev-tools"
-    "libzstd-dev"
+  "cmake"
+  "build-essential"
+  "rustc"
+  "cargo"
+  "libibus-1.0-dev"
+  "qtbase5-dev"
+  "qtbase5-dev-tools"
+  "libzstd-dev"
 )
 
 prepare() {
-    cd "${srcdir}/OpenBangla-Keyboard"
-    git submodule update --init --recursive
-    pkgver="r$(git rev-list --count HEAD).$(git rev-parse --short HEAD)"
+  cd "${srcdir}/OpenBangla-Keyboard"
+  git submodule update --init --recursive
+  pkgver="r$(git rev-list --count HEAD).$(git rev-parse --short HEAD)"
 }
 
 build() {
-    cd "${srcdir}/OpenBangla-Keyboard"
-    mkdir -p build && cd build
-    cmake .. \
-        -DCMAKE_INSTALL_PREFIX=/usr \
-        -DCMAKE_BUILD_TYPE=Release
-    make -j"${NCPU}"
+  cd "${srcdir}/OpenBangla-Keyboard"
+  mkdir -p build && cd build
+  cmake .. \
+    -DCMAKE_INSTALL_PREFIX=/usr \
+    -DCMAKE_BUILD_TYPE=Release
+  make -j"${NCPU}"
 }
 
 package() {
-    cd "${srcdir}/OpenBangla-Keyboard/build"
-    make install DESTDIR="${pkgdir}"
+  cd "${srcdir}/OpenBangla-Keyboard/build"
+  make install DESTDIR="${pkgdir}"
 }

--- a/packages/openbangla-keyboard-git/openbangla-keyboard-git.pacscript
+++ b/packages/openbangla-keyboard-git/openbangla-keyboard-git.pacscript
@@ -32,12 +32,6 @@ makedepends=(
   "libzstd-dev"
 )
 
-prepare() {
-  cd "${srcdir}/OpenBangla-Keyboard"
-  git submodule update --init --recursive
-  pkgver="r$(git rev-list --count HEAD).$(git rev-parse --short HEAD)"
-}
-
 build() {
   cd "${srcdir}/OpenBangla-Keyboard"
   mkdir -p build && cd build

--- a/packages/openbangla-keyboard-git/openbangla-keyboard-git.pacscript
+++ b/packages/openbangla-keyboard-git/openbangla-keyboard-git.pacscript
@@ -1,7 +1,7 @@
 pkgname="openbangla-keyboard-git"
 gives="openbangla-keyboard"
 pkgdesc="Unicode compliant Bengali input method"
-url="https://github.com/OpenBangla/OpenBangla-Keyboard"
+url='https://github.com/OpenBangla/OpenBangla-Keyboard'
 maintainer=("Niamot <58494481+niam0t@users.noreply.github.com>")
 
 external_connection="true"

--- a/packages/openbangla-keyboard-git/openbangla-keyboard-git.pacscript
+++ b/packages/openbangla-keyboard-git/openbangla-keyboard-git.pacscript
@@ -9,7 +9,7 @@ external_connection="true"
 arch=("amd64")
 source=("git+https://github.com/OpenBangla/OpenBangla-Keyboard.git")
 repology=("project: ${gives}")
-pkgver="0.0.0"
+pkgver="0.0.1"
 
 replaces=("${gives}")
 conflicts=("${gives}")

--- a/packages/openbangla-keyboard-git/openbangla-keyboard-git.pacscript
+++ b/packages/openbangla-keyboard-git/openbangla-keyboard-git.pacscript
@@ -1,6 +1,6 @@
 pkgname="openbangla-keyboard-git"
 gives="openbangla-keyboard"
-pkgdesc="An OpenSource, Unicode compliant Bengali Input Method"
+pkgdesc="Unicode compliant Bengali input method"
 url="https://github.com/OpenBangla/OpenBangla-Keyboard"
 maintainer=("Niamot <58494481+niam0t@users.noreply.github.com>")
 

--- a/srclist
+++ b/srclist
@@ -11258,6 +11258,33 @@ pkgbase = onnxruntime-gpu-bin
 
 pkgname = onnxruntime-gpu-bin
 ---
+pkgbase = openbangla-keyboard-git
+	gives = openbangla-keyboard
+	pkgver = 0.0.0
+	pkgdesc = An OpenSource, Unicode compliant Bengali Input Method
+	url = https://github.com/OpenBangla/OpenBangla-Keyboard
+	arch = amd64
+	depends = ibus
+	depends = libzstd1
+	depends = libqt5gui5
+	depends = libqt5widgets5
+	depends = libqt5network5
+	makedepends = cmake
+	makedepends = build-essential
+	makedepends = rustc
+	makedepends = cargo
+	makedepends = libibus-1.0-dev
+	makedepends = qtbase5-dev
+	makedepends = qtbase5-dev-tools
+	makedepends = libzstd-dev
+	conflicts = openbangla-keyboard
+	replaces = openbangla-keyboard
+	maintainer = Niamot <58494481+niam0t@users.noreply.github.com>
+	repology = project: openbangla-keyboard
+	source = git+https://github.com/OpenBangla/OpenBangla-Keyboard.git
+
+pkgname = openbangla-keyboard-git
+---
 pkgbase = opendoas-git
 	gives = opendoas
 	pkgver = 6.8.2


### PR DESCRIPTION
Adds a pacscript for openbangla-keyboard-git, which builds the latest OpenBangla-Keyboard (IBus-based Bengali input method) directly from the master branch.
- Requires network access during build (external_connection=true) to allow Cargo to fetch riti engine.
- Maps to the upstream Repology project "openbangla-keyboard"