### PR TITLE
upd(eclipse-rcp-bin): `4.39` -> `4.40`

### DIFF
--- a/packages/eclipse-rcp-bin/.SRCINFO
+++ b/packages/eclipse-rcp-bin/.SRCINFO
@@ -1,5 +1,5 @@
 pkgbase = eclipse-rcp-bin
-	pkgver = 4.39
+	pkgver = 4.40
 	pkgdesc = IDE for Rich Client Platform (RCP) and Remote Application Platform (RAP)
 	url = https://eclipse.org/ide
 	arch = amd64
@@ -7,9 +7,10 @@ pkgbase = eclipse-rcp-bin
 	backup = usr/lib/eclipse/eclipse.ini
 	license = EPL-2.0
 	maintainer = Matthias Mailänder <matthias@mailaender.name>
-	source = https://cdimage.debian.org/mirror/eclipse.org/technology/epp/downloads/release/2026-03/R/eclipse-rcp-2026-03-R-linux-gtk-x86_64.tar.gz
+	repology = project: eclipse-rcp
+	source = https://cdimage.debian.org/mirror/eclipse.org/technology/epp/downloads/release/2026-06/R/eclipse-rcp-2026-06-R-linux-gtk-x86_64.tar.gz
 	source = eclipse.desktop::https://raw.githubusercontent.com/eclipse-linuxtools/org.eclipse.linuxtools.eclipse-build/refs/heads/master/desktopintegration/eclipse.desktop
-	sha512sums = 2e3af4cd1a8a0581ffe872fbaf29215166f5c2b7ac414a2d51150f6d2e7b54b0f843337055b8e2abb04af9e4d2eba815e6081ae7f84596897c974927c25f7cfd
+	sha512sums = df0c35a056f4f151f0ee5ed36869aff023a2b9418ac1ef8b77938f4978de1a9c71b760e927b354175002a9e1385c981ad1d93a78561c30230945e589a6b97ecc
 	sha512sums = 824875ab1454349a58eb2bb6fd70edd5e7a8e14a9b999372024374a1e04722398095db9bdba91b17bfb424c1e1271446f0370c79596f35fb516dbada31aebec5
 
 pkgname = eclipse-rcp-bin

--- a/packages/eclipse-rcp-bin/eclipse-rcp-bin.pacscript
+++ b/packages/eclipse-rcp-bin/eclipse-rcp-bin.pacscript
@@ -1,6 +1,6 @@
 pkgname="eclipse-rcp-bin"
-pkgver="4.39"
-_release="2026-03"
+pkgver="4.40"
+_release="2026-06"
 pkgdesc="IDE for Rich Client Platform (RCP) and Remote Application Platform (RAP)"
 arch=('amd64')
 url="https://eclipse.org/ide"
@@ -8,10 +8,11 @@ license=('EPL-2.0')
 depends=('libwebkit2gtk-4.1-0')
 source=("https://cdimage.debian.org/mirror/eclipse.org/technology/epp/downloads/release/${_release}/R/eclipse-rcp-${_release}-R-linux-gtk-x86_64.tar.gz"
   "eclipse.desktop::https://raw.githubusercontent.com/eclipse-linuxtools/org.eclipse.linuxtools.eclipse-build/refs/heads/master/desktopintegration/eclipse.desktop")
-sha512sums=('2e3af4cd1a8a0581ffe872fbaf29215166f5c2b7ac414a2d51150f6d2e7b54b0f843337055b8e2abb04af9e4d2eba815e6081ae7f84596897c974927c25f7cfd'
+sha512sums=('df0c35a056f4f151f0ee5ed36869aff023a2b9418ac1ef8b77938f4978de1a9c71b760e927b354175002a9e1385c981ad1d93a78561c30230945e589a6b97ecc'
   '824875ab1454349a58eb2bb6fd70edd5e7a8e14a9b999372024374a1e04722398095db9bdba91b17bfb424c1e1271446f0370c79596f35fb516dbada31aebec5')
 backup=('usr/lib/eclipse/eclipse.ini')
 maintainer=("Matthias Mailänder <matthias@mailaender.name>")
+repology=("project: eclipse-rcp")
 
 package() {
   install -d "${pkgdir}/usr/lib"

--- a/srclist
+++ b/srclist
@@ -2841,7 +2841,7 @@ pkgbase = easy-zsh-config-git
 pkgname = easy-zsh-config-git
 ---
 pkgbase = eclipse-rcp-bin
-	pkgver = 4.39
+	pkgver = 4.40
 	pkgdesc = IDE for Rich Client Platform (RCP) and Remote Application Platform (RAP)
 	url = https://eclipse.org/ide
 	arch = amd64
@@ -2849,9 +2849,10 @@ pkgbase = eclipse-rcp-bin
 	backup = usr/lib/eclipse/eclipse.ini
 	license = EPL-2.0
 	maintainer = Matthias Mailänder <matthias@mailaender.name>
-	source = https://cdimage.debian.org/mirror/eclipse.org/technology/epp/downloads/release/2026-03/R/eclipse-rcp-2026-03-R-linux-gtk-x86_64.tar.gz
+	repology = project: eclipse-rcp
+	source = https://cdimage.debian.org/mirror/eclipse.org/technology/epp/downloads/release/2026-06/R/eclipse-rcp-2026-06-R-linux-gtk-x86_64.tar.gz
 	source = eclipse.desktop::https://raw.githubusercontent.com/eclipse-linuxtools/org.eclipse.linuxtools.eclipse-build/refs/heads/master/desktopintegration/eclipse.desktop
-	sha512sums = 2e3af4cd1a8a0581ffe872fbaf29215166f5c2b7ac414a2d51150f6d2e7b54b0f843337055b8e2abb04af9e4d2eba815e6081ae7f84596897c974927c25f7cfd
+	sha512sums = df0c35a056f4f151f0ee5ed36869aff023a2b9418ac1ef8b77938f4978de1a9c71b760e927b354175002a9e1385c981ad1d93a78561c30230945e589a6b97ecc
 	sha512sums = 824875ab1454349a58eb2bb6fd70edd5e7a8e14a9b999372024374a1e04722398095db9bdba91b17bfb424c1e1271446f0370c79596f35fb516dbada31aebec5
 
 pkgname = eclipse-rcp-bin


### PR DESCRIPTION
https://eclipse.dev/eclipse/markdown/?f=news/4.40/index.md