### PR TITLE
upd(vscode-deb): `1.122.0` -> `1.124.0`

### DIFF
--- a/packages/vscode-deb/.SRCINFO
+++ b/packages/vscode-deb/.SRCINFO
@@ -1,6 +1,6 @@
 pkgbase = vscode-deb
 	gives = code
-	pkgver = 1.123.0
+	pkgver = 1.124.0
 	pkgdesc = lightweight but powerful source code editor
 	url = https://code.visualstudio.com/
 	arch = amd64
@@ -8,11 +8,11 @@ pkgbase = vscode-deb
 	arch = armhf
 	makedepends = gpg
 	maintainer = Diegiwg <diegiwg@gmail.com>
-	source_amd64 = https://packages.microsoft.com/repos/code/pool/main/c/code/code_1.123.0-1780481570_amd64.deb
-	sha256sums_amd64 = c94076e6855f2e360ff5cf6824a8bb8890fb748f41476e5e4c33f4c54696b70d
-	source_arm64 = https://packages.microsoft.com/repos/code/pool/main/c/code/code_1.123.0-1780481584_arm64.deb
-	sha256sums_arm64 = 48d5d5c1da4898e534fc11694900423c4197a030a09093d8eb93bd3c231415c0
-	source_armhf = https://packages.microsoft.com/repos/code/pool/main/c/code/code_1.123.0-1780481487_armhf.deb
-	sha256sums_armhf = c45930af28de189fc3b3026b5354e687edff10654bd393b64e35bf13990dfac0
+	source_amd64 = https://packages.microsoft.com/repos/code/pool/main/c/code/code_1.124.0-1781066808_amd64.deb
+	sha256sums_amd64 = 544f8e6638be2b5ad00be8609ba192860733ffd5b60572755f942d2ca4d98f8b
+	source_arm64 = https://packages.microsoft.com/repos/code/pool/main/c/code/code_1.124.0-1781066868_arm64.deb
+	sha256sums_arm64 = 1fa99070d580849680ca3fefe00a06df36d155d03bed948cb98881d3acf0a852
+	source_armhf = https://packages.microsoft.com/repos/code/pool/main/c/code/code_1.124.0-1781066575_armhf.deb
+	sha256sums_armhf = 562a10107bf25231898d37038a1b0579c7c66e6ed6fa9b4ffa90c04c24c67e70
 
 pkgname = vscode-deb

--- a/packages/vscode-deb/vscode-deb.pacscript
+++ b/packages/vscode-deb/vscode-deb.pacscript
@@ -1,16 +1,16 @@
 pkgname="vscode-deb"
 arch=("amd64" "arm64" "armhf")
 gives="code"
-pkgver="1.123.0"
+pkgver="1.124.0"
 url='https://code.visualstudio.com/'
 pkgdesc="lightweight but powerful source code editor"
 project=("project: vscode")
 makedepends=("gpg")
 maintainer=("Diegiwg <diegiwg@gmail.com>")
 
-source_amd64=("https://packages.microsoft.com/repos/code/pool/main/c/code/code_1.123.0-1780481570_amd64.deb")
-sha256sums_amd64=("c94076e6855f2e360ff5cf6824a8bb8890fb748f41476e5e4c33f4c54696b70d")
-source_arm64=("https://packages.microsoft.com/repos/code/pool/main/c/code/code_1.123.0-1780481584_arm64.deb")
-sha256sums_arm64=("48d5d5c1da4898e534fc11694900423c4197a030a09093d8eb93bd3c231415c0")
-source_armhf=("https://packages.microsoft.com/repos/code/pool/main/c/code/code_1.123.0-1780481487_armhf.deb")
-sha256sums_armhf=("c45930af28de189fc3b3026b5354e687edff10654bd393b64e35bf13990dfac0")
+source_amd64=("https://packages.microsoft.com/repos/code/pool/main/c/${gives}/${gives}_${pkgver}-1781066808_amd64.deb")
+sha256sums_amd64=("544f8e6638be2b5ad00be8609ba192860733ffd5b60572755f942d2ca4d98f8b")
+source_arm64=("https://packages.microsoft.com/repos/code/pool/main/c/${gives}/${gives}_${pkgver}-1781066868_arm64.deb")
+sha256sums_arm64=("1fa99070d580849680ca3fefe00a06df36d155d03bed948cb98881d3acf0a852")
+source_armhf=("https://packages.microsoft.com/repos/code/pool/main/c/${gives}/${gives}_${pkgver}-1781066575_armhf.deb")
+sha256sums_armhf=("562a10107bf25231898d37038a1b0579c7c66e6ed6fa9b4ffa90c04c24c67e70")

--- a/srclist
+++ b/srclist
@@ -17088,7 +17088,7 @@ pkgname = vkroots-git
 ---
 pkgbase = vscode-deb
 	gives = code
-	pkgver = 1.123.0
+	pkgver = 1.124.0
 	pkgdesc = lightweight but powerful source code editor
 	url = https://code.visualstudio.com/
 	arch = amd64
@@ -17096,12 +17096,12 @@ pkgbase = vscode-deb
 	arch = armhf
 	makedepends = gpg
 	maintainer = Diegiwg <diegiwg@gmail.com>
-	source_amd64 = https://packages.microsoft.com/repos/code/pool/main/c/code/code_1.123.0-1780481570_amd64.deb
-	sha256sums_amd64 = c94076e6855f2e360ff5cf6824a8bb8890fb748f41476e5e4c33f4c54696b70d
-	source_arm64 = https://packages.microsoft.com/repos/code/pool/main/c/code/code_1.123.0-1780481584_arm64.deb
-	sha256sums_arm64 = 48d5d5c1da4898e534fc11694900423c4197a030a09093d8eb93bd3c231415c0
-	source_armhf = https://packages.microsoft.com/repos/code/pool/main/c/code/code_1.123.0-1780481487_armhf.deb
-	sha256sums_armhf = c45930af28de189fc3b3026b5354e687edff10654bd393b64e35bf13990dfac0
+	source_amd64 = https://packages.microsoft.com/repos/code/pool/main/c/code/code_1.124.0-1781066808_amd64.deb
+	sha256sums_amd64 = 544f8e6638be2b5ad00be8609ba192860733ffd5b60572755f942d2ca4d98f8b
+	source_arm64 = https://packages.microsoft.com/repos/code/pool/main/c/code/code_1.124.0-1781066868_arm64.deb
+	sha256sums_arm64 = 1fa99070d580849680ca3fefe00a06df36d155d03bed948cb98881d3acf0a852
+	source_armhf = https://packages.microsoft.com/repos/code/pool/main/c/code/code_1.124.0-1781066575_armhf.deb
+	sha256sums_armhf = 562a10107bf25231898d37038a1b0579c7c66e6ed6fa9b4ffa90c04c24c67e70
 
 pkgname = vscode-deb
 ---


### PR DESCRIPTION
This now uses $gives and $pckver vars in the pacscript.