### PR TITLE
add: `age-plugin-yubikey`

### DIFF
--- a/packagelist
+++ b/packagelist
@@ -4,6 +4,7 @@ abdownloadmanager
 adapta-gtk-theme-git
 adw-gtk-theme
 adw-gtk3
+age-plugin-yubikey
 alacritty
 amf-headers
 amfora-bin

--- a/packages/age-plugin-yubikey/.SRCINFO
+++ b/packages/age-plugin-yubikey/.SRCINFO
@@ -1,6 +1,5 @@
 pkgbase = age-plugin-yubikey
 	pkgver = 0.5.1
-	pkgrel = 1
 	pkgdesc = YubiKey plugin for age clients
 	url = https://github.com/str4d/age-plugin-yubikey
 	arch = amd64

--- a/packages/age-plugin-yubikey/.SRCINFO
+++ b/packages/age-plugin-yubikey/.SRCINFO
@@ -1,0 +1,20 @@
+pkgbase = age-plugin-yubikey
+	pkgver = 0.5.1
+	pkgrel = 1
+	pkgdesc = YubiKey plugin for age clients
+	url = https://github.com/str4d/age-plugin-yubikey
+	arch = amd64
+	arch = arm64
+	depends = pcscd
+	depends = libpcsclite1
+	makedepends = cargo
+	makedepends = libpcsclite-dev
+	makedepends = pkg-config
+	license = Apache-2.0
+	license = MIT
+	maintainer = Abhinandan <dev@nmabhinandan.xyz>
+	repology = project: age-plugin-yubikey
+	source = age-plugin-yubikey-0.5.1.tar.gz::https://github.com/str4d/age-plugin-yubikey/archive/refs/tags/v0.5.1.tar.gz
+	sha256sums = SKIP
+
+pkgname = age-plugin-yubikey

--- a/packages/age-plugin-yubikey/.SRCINFO
+++ b/packages/age-plugin-yubikey/.SRCINFO
@@ -7,7 +7,7 @@ pkgbase = age-plugin-yubikey
 	arch = arm64
 	depends = pcscd
 	depends = libpcsclite1
-	makedepends = cargo
+	makedepends = cargo>=1.70
 	makedepends = libpcsclite-dev
 	makedepends = pkg-config
 	license = Apache-2.0

--- a/packages/age-plugin-yubikey/.SRCINFO
+++ b/packages/age-plugin-yubikey/.SRCINFO
@@ -2,8 +2,7 @@ pkgbase = age-plugin-yubikey
 	pkgver = 0.5.1
 	pkgdesc = YubiKey plugin for age clients
 	url = https://github.com/str4d/age-plugin-yubikey
-	arch = amd64
-	arch = arm64
+	arch = any
 	depends = pcscd
 	depends = libpcsclite1
 	makedepends = cargo>=1.70

--- a/packages/age-plugin-yubikey/age-plugin-yubikey.pacscript
+++ b/packages/age-plugin-yubikey/age-plugin-yubikey.pacscript
@@ -1,7 +1,7 @@
 pkgname="age-plugin-yubikey"
 pkgver="0.5.1"
 pkgdesc="YubiKey plugin for age clients"
-arch=("amd64" "arm64")
+arch=("any")
 url='https://github.com/str4d/age-plugin-yubikey'
 license=("Apache-2.0" "MIT")
 maintainer=("Abhinandan <dev@nmabhinandan.xyz>")

--- a/packages/age-plugin-yubikey/age-plugin-yubikey.pacscript
+++ b/packages/age-plugin-yubikey/age-plugin-yubikey.pacscript
@@ -1,6 +1,5 @@
 pkgname="age-plugin-yubikey"
 pkgver="0.5.1"
-pkgrel="1"
 pkgdesc="YubiKey plugin for age clients"
 arch=("amd64" "arm64")
 url='https://github.com/str4d/age-plugin-yubikey'

--- a/packages/age-plugin-yubikey/age-plugin-yubikey.pacscript
+++ b/packages/age-plugin-yubikey/age-plugin-yubikey.pacscript
@@ -1,0 +1,45 @@
+pkgname="age-plugin-yubikey"
+pkgver="0.5.1"
+pkgrel="1"
+pkgdesc="YubiKey plugin for age clients"
+arch=("amd64" "arm64")
+url="https://github.com/str4d/age-plugin-yubikey"
+license=("Apache-2.0" "MIT")
+maintainer=("Abhinandan <dev@nmabhinandan.xyz>")
+repology=("project: age-plugin-yubikey")
+external_connection=true
+
+depends=(
+  "pcscd"
+  "libpcsclite1"
+)
+
+makedepends=(
+  "cargo"
+  "libpcsclite-dev"
+  "pkg-config"
+)
+
+source=("${pkgname}-${pkgver}.tar.gz::https://github.com/str4d/age-plugin-yubikey/archive/refs/tags/v${pkgver}.tar.gz")
+sha256sums=("SKIP")
+
+build() {
+  cd "${pkgname}-${pkgver}"
+  cargo build -j"${NCPU}" --release --locked
+}
+
+package() {
+  cd "${pkgname}-${pkgver}"
+
+  install -Dm755 "target/release/age-plugin-yubikey" \
+    "${pkgdir}/usr/bin/age-plugin-yubikey"
+
+  install -Dm644 "LICENSE-APACHE" \
+    "${pkgdir}/usr/share/licenses/${pkgname}/LICENSE-APACHE"
+
+  install -Dm644 "LICENSE-MIT" \
+    "${pkgdir}/usr/share/licenses/${pkgname}/LICENSE-MIT"
+
+  install -Dm644 "README.md" \
+    "${pkgdir}/usr/share/doc/${pkgname}/README.md"
+}

--- a/packages/age-plugin-yubikey/age-plugin-yubikey.pacscript
+++ b/packages/age-plugin-yubikey/age-plugin-yubikey.pacscript
@@ -3,23 +3,20 @@ pkgver="0.5.1"
 pkgrel="1"
 pkgdesc="YubiKey plugin for age clients"
 arch=("amd64" "arm64")
-url="https://github.com/str4d/age-plugin-yubikey"
+url='https://github.com/str4d/age-plugin-yubikey'
 license=("Apache-2.0" "MIT")
 maintainer=("Abhinandan <dev@nmabhinandan.xyz>")
 repology=("project: age-plugin-yubikey")
 external_connection=true
-
 depends=(
   "pcscd"
   "libpcsclite1"
 )
-
 makedepends=(
-  "cargo"
+  "cargo>=1.70"
   "libpcsclite-dev"
   "pkg-config"
 )
-
 source=("${pkgname}-${pkgver}.tar.gz::https://github.com/str4d/age-plugin-yubikey/archive/refs/tags/v${pkgver}.tar.gz")
 sha256sums=("SKIP")
 

--- a/srclist
+++ b/srclist
@@ -92,7 +92,6 @@ pkgname = adw-gtk3
 ---
 pkgbase = age-plugin-yubikey
 	pkgver = 0.5.1
-	pkgrel = 1
 	pkgdesc = YubiKey plugin for age clients
 	url = https://github.com/str4d/age-plugin-yubikey
 	arch = amd64

--- a/srclist
+++ b/srclist
@@ -90,6 +90,27 @@ pkgbase = adw-gtk3
 
 pkgname = adw-gtk3
 ---
+pkgbase = age-plugin-yubikey
+	pkgver = 0.5.1
+	pkgrel = 1
+	pkgdesc = YubiKey plugin for age clients
+	url = https://github.com/str4d/age-plugin-yubikey
+	arch = amd64
+	arch = arm64
+	depends = pcscd
+	depends = libpcsclite1
+	makedepends = cargo
+	makedepends = libpcsclite-dev
+	makedepends = pkg-config
+	license = Apache-2.0
+	license = MIT
+	maintainer = Abhinandan <dev@nmabhinandan.xyz>
+	repology = project: age-plugin-yubikey
+	source = age-plugin-yubikey-0.5.1.tar.gz::https://github.com/str4d/age-plugin-yubikey/archive/refs/tags/v0.5.1.tar.gz
+	sha256sums = SKIP
+
+pkgname = age-plugin-yubikey
+---
 pkgbase = alacritty
 	pkgver = 0.17.0
 	pkgdesc = A fast, cross-platform, OpenGL terminal emulator

--- a/srclist
+++ b/srclist
@@ -94,8 +94,7 @@ pkgbase = age-plugin-yubikey
 	pkgver = 0.5.1
 	pkgdesc = YubiKey plugin for age clients
 	url = https://github.com/str4d/age-plugin-yubikey
-	arch = amd64
-	arch = arm64
+	arch = any
 	depends = pcscd
 	depends = libpcsclite1
 	makedepends = cargo>=1.70

--- a/srclist
+++ b/srclist
@@ -99,7 +99,7 @@ pkgbase = age-plugin-yubikey
 	arch = arm64
 	depends = pcscd
 	depends = libpcsclite1
-	makedepends = cargo
+	makedepends = cargo>=1.70
 	makedepends = libpcsclite-dev
 	makedepends = pkg-config
 	license = Apache-2.0


### PR DESCRIPTION
Adds [age-plugin-yubikey](https://github.com/str4d/age-plugin-yubikey). Uses cargo to compile the project from source hence needs external_connection=true to fetch deps.