### PR TITLE
upd(fastfetch-git): `2.37.0` -> `2.65.2`

### DIFF
--- a/packages/fastfetch-git/.SRCINFO
+++ b/packages/fastfetch-git/.SRCINFO
@@ -1,6 +1,6 @@
 pkgbase = fastfetch-git
 	gives = fastfetch
-	pkgver = 2.37.0
+	pkgver = 2.65.2
 	pkgdesc = Like neofetch, but much faster because written in c
 	arch = any
 	makedepends = cmake>=3.12

--- a/packages/fastfetch-git/fastfetch-git.pacscript
+++ b/packages/fastfetch-git/fastfetch-git.pacscript
@@ -12,7 +12,7 @@ pkgdesc="Like neofetch, but much faster because written in c"
 source=("https://github.com/LinusDierheimer/fastfetch.git")
 arch=("any")
 license=("MIT")
-pkgver="2.37.0"
+pkgver="2.65.2"
 repology=("project: ${gives}")
 checkdepends=("cmake")
 makedepends=("cmake>=3.12" "pkg-config" "python3" "libvulkan-dev" "libwayland-dev" "libxcb-randr0-dev" "libxrandr-dev" "libdrm-dev" "libdconf-dev" "zlib1g-dev" "libchafa-dev" "libxfconf-0-dev" "libdbus-1-dev" "libmagickcore-dev" "libegl-dev" "libosmesa6-dev" "ocl-icd-opencl-dev" "libpulse-dev" "libddcutil-dev" "libelf-dev")

--- a/srclist
+++ b/srclist
@@ -3394,7 +3394,7 @@ pkgname = fastcompmgr-git
 ---
 pkgbase = fastfetch-git
 	gives = fastfetch
-	pkgver = 2.37.0
+	pkgver = 2.65.2
 	pkgdesc = Like neofetch, but much faster because written in c
 	arch = any
 	makedepends = cmake>=3.12


### PR DESCRIPTION
Updates fastfetch-git to latest commit.

- Tested locally with `pacstall -I fastfetch-git` - builds successfully
- Updated pkgver and .SRCINFO per Pacstall Maintaining-a-Package guide