### PR TITLE
upd(git-credential-manager-core-deb): `2.8.0` -> `2.9.1`

### DIFF
--- a/packages/git-credential-manager-core-deb/.SRCINFO
+++ b/packages/git-credential-manager-core-deb/.SRCINFO
@@ -1,12 +1,12 @@
 pkgbase = git-credential-manager-core-deb
 	gives = gcm
-	pkgver = 2.8.0
+	pkgver = 2.9.1
 	pkgdesc = Secure, cross-platform Git credential storage with authentication to GitHub, Azure Repos, and other popular Git hosting services
 	arch = amd64
 	depends = git
 	maintainer = Oren Klopfer <oren@taumoda.com>
 	repology = project: gcm
-	source = https://github.com/git-ecosystem/git-credential-manager/releases/download/v2.8.0/gcm-linux-x64-2.8.0.deb
-	sha256sums = c7bbf9785c3e8166ceedb66a7e0bfb40e6655ef504af5ca7977b516c5497aff6
+	source = https://github.com/git-ecosystem/git-credential-manager/releases/download/v2.9.1/gcm-linux-x64-2.9.1.deb
+	sha256sums = a0c59d2ea873a930fd1c41031a25cb31055d31baaf80c10726847e1c1f7aa951
 
 pkgname = git-credential-manager-core-deb

--- a/packages/git-credential-manager-core-deb/git-credential-manager-core-deb.pacscript
+++ b/packages/git-credential-manager-core-deb/git-credential-manager-core-deb.pacscript
@@ -1,11 +1,11 @@
 pkgname="git-credential-manager-core-deb"
 gives="gcm"
 repology=("project: ${gives}")
-pkgver="2.8.0"
+pkgver="2.9.1"
 depends=("git")
 arch=('amd64')
 _url_arch=$([[ ${arch[0]} == "amd64" ]] && echo "x64" || echo "${arch[0]}")
 source=("https://github.com/git-ecosystem/git-credential-manager/releases/download/v${pkgver}/${gives}-linux-${_url_arch}-${pkgver}.deb")
 pkgdesc="Secure, cross-platform Git credential storage with authentication to GitHub, Azure Repos, and other popular Git hosting services"
-sha256sums=("c7bbf9785c3e8166ceedb66a7e0bfb40e6655ef504af5ca7977b516c5497aff6")
+sha256sums=("a0c59d2ea873a930fd1c41031a25cb31055d31baaf80c10726847e1c1f7aa951")
 maintainer=("Oren Klopfer <oren@taumoda.com>")

--- a/srclist
+++ b/srclist
@@ -4323,14 +4323,14 @@ pkgname = git-butler-deb
 ---
 pkgbase = git-credential-manager-core-deb
 	gives = gcm
-	pkgver = 2.8.0
+	pkgver = 2.9.1
 	pkgdesc = Secure, cross-platform Git credential storage with authentication to GitHub, Azure Repos, and other popular Git hosting services
 	arch = amd64
 	depends = git
 	maintainer = Oren Klopfer <oren@taumoda.com>
 	repology = project: gcm
-	source = https://github.com/git-ecosystem/git-credential-manager/releases/download/v2.8.0/gcm-linux-x64-2.8.0.deb
-	sha256sums = c7bbf9785c3e8166ceedb66a7e0bfb40e6655ef504af5ca7977b516c5497aff6
+	source = https://github.com/git-ecosystem/git-credential-manager/releases/download/v2.9.1/gcm-linux-x64-2.9.1.deb
+	sha256sums = a0c59d2ea873a930fd1c41031a25cb31055d31baaf80c10726847e1c1f7aa951
 
 pkgname = git-credential-manager-core-deb
 ---


### PR DESCRIPTION
Updated `git-credential-manager-core-deb` to version `2.9.1`.