### PR TITLE
upd(google-chrome-deb): `137.0.7151.119` -> `151.0.7922.137`

### DIFF
--- a/packages/google-chrome-deb/.SRCINFO
+++ b/packages/google-chrome-deb/.SRCINFO
@@ -1,14 +1,15 @@
 pkgbase = google-chrome-deb
 	gives = google-chrome-stable
-	pkgver = 137.0.7151.119
+	pkgver = 151.0.7922.137
 	pkgdesc = The popular and trusted web browser by Google
 	arch = amd64
 	replaces = google-chrome-stable
 	maintainer = Oren Klopfer <oren@taumoda.com>
 	maintainer = James Ed Randson <jimedrand@disroot.org>
 	repology = project: google-chrome
+	repology = visiblename: google-chrome
 	repology = repo: aur
-	source = https://dl.google.com/linux/chrome/deb/pool/main/g/google-chrome-stable/google-chrome-stable_137.0.7151.119-1_amd64.deb
-	sha256sums = 11c537a6e94fd48fbc90abed1c94af35ab68dbf6f317e5da64802f266e8a187a
+	source = https://dl.google.com/linux/chrome/deb/pool/main/g/google-chrome-stable/google-chrome-stable_151.0.7922.137-1_amd64.deb
+	sha256sums = e6dabf044cf9cd0279cfe86efa431682c18bfc06d06339ce055aaa87ae871727
 
 pkgname = google-chrome-deb

--- a/packages/google-chrome-deb/google-chrome-deb.pacscript
+++ b/packages/google-chrome-deb/google-chrome-deb.pacscript
@@ -1,10 +1,10 @@
 pkgname="google-chrome-deb"
 gives="google-chrome-stable"
-repology=("project: google-chrome" "repo: aur")
+repology=("project: google-chrome" "visiblename: google-chrome" "repo: aur")
 replaces=("${gives}")
-pkgver="137.0.7151.119"
+pkgver="151.0.7922.137"
 source=("https://dl.google.com/linux/chrome/deb/pool/main/g/${gives}/${gives}_${pkgver}-1_amd64.deb")
 pkgdesc="The popular and trusted web browser by Google"
-sha256sums=("11c537a6e94fd48fbc90abed1c94af35ab68dbf6f317e5da64802f266e8a187a")
+sha256sums=("e6dabf044cf9cd0279cfe86efa431682c18bfc06d06339ce055aaa87ae871727")
 arch=('amd64')
 maintainer=("Oren Klopfer <oren@taumoda.com>" "James Ed Randson <jimedrand@disroot.org>")

--- a/srclist
+++ b/srclist
@@ -4895,16 +4895,17 @@ pkgname = google-chrome-beta-deb
 ---
 pkgbase = google-chrome-deb
 	gives = google-chrome-stable
-	pkgver = 137.0.7151.119
+	pkgver = 151.0.7922.137
 	pkgdesc = The popular and trusted web browser by Google
 	arch = amd64
 	replaces = google-chrome-stable
 	maintainer = Oren Klopfer <oren@taumoda.com>
 	maintainer = James Ed Randson <jimedrand@disroot.org>
 	repology = project: google-chrome
+	repology = visiblename: google-chrome
 	repology = repo: aur
-	source = https://dl.google.com/linux/chrome/deb/pool/main/g/google-chrome-stable/google-chrome-stable_137.0.7151.119-1_amd64.deb
-	sha256sums = 11c537a6e94fd48fbc90abed1c94af35ab68dbf6f317e5da64802f266e8a187a
+	source = https://dl.google.com/linux/chrome/deb/pool/main/g/google-chrome-stable/google-chrome-stable_151.0.7922.137-1_amd64.deb
+	sha256sums = e6dabf044cf9cd0279cfe86efa431682c18bfc06d06339ce055aaa87ae871727
 
 pkgname = google-chrome-deb
 ---


### PR DESCRIPTION
I also needed to adjust the repology filters, because otherwise we always get the latest canary version, which we don't want for a stable google-chrome-deb.