### PR TITLE
upd(notesnook-app): `3.3.23` -> `3.4.7`

### DIFF
--- a/packages/notesnook-app/.SRCINFO
+++ b/packages/notesnook-app/.SRCINFO
@@ -1,18 +1,18 @@
 pkgbase = notesnook-app
 	gives = notesnook
-	pkgver = 3.3.23
+	pkgver = 3.4.7
 	pkgdesc = End-to-end encrypted note taking alternative to Evernote
 	url = https://notesnook.com
 	arch = amd64
 	arch = arm64
 	license = GPL-3.0-only
-	maintainer = villamorrd <villamorrd@students.nu-moa.edu.ph>
+	maintainer = Tai Lam <taivlam-aur-mpr.tinsmith796@silomails.com>
 	repology = project: notesnook
-	source = https://raw.githubusercontent.com/streetwriters/notesnook/refs/tags/v3.3.23/resources/icon.png
+	source = https://raw.githubusercontent.com/streetwriters/notesnook/refs/tags/v3.4.7/resources/icon.png
 	sha256sums = SKIP
-	source_amd64 = notesnook-3.3.23.AppImage::https://github.com/streetwriters/notesnook/releases/download/v3.3.23/notesnook_linux_x86_64.AppImage
-	sha256sums_amd64 = c49738761f754dcc6f07cdfae1b557a80ba9c97c599a928cceca1ee399869a12
-	source_arm64 = notesnook-3.3.23.AppImage::https://github.com/streetwriters/notesnook/releases/download/v3.3.23/notesnook_linux_arm64.AppImage
-	sha256sums_arm64 = 337b01516b68781e3a25f129d6841ee136e9c29aa0a31b50df5dd16e64b46864
+	source_amd64 = notesnook-3.4.7.AppImage::https://github.com/streetwriters/notesnook/releases/download/v3.4.7/notesnook_linux_x86_64.AppImage
+	sha256sums_amd64 = 37035f853b9f276e70a9d66e45757bdda54e1e376a18f4388d974c5da5bedef3
+	source_arm64 = notesnook-3.4.7.AppImage::https://github.com/streetwriters/notesnook/releases/download/v3.4.7/notesnook_linux_arm64.AppImage
+	sha256sums_arm64 = 7408cb3a25afa33268cfc3bf7de2ab338fea13d5d2f3720d038202e20599b60d
 
 pkgname = notesnook-app

--- a/packages/notesnook-app/notesnook-app.pacscript
+++ b/packages/notesnook-app/notesnook-app.pacscript
@@ -1,17 +1,17 @@
 pkgname="notesnook-app"
 repology=("project: notesnook")
 arch=('amd64' 'arm64')
-pkgver="3.3.23"
+pkgver="3.4.7"
 url='https://notesnook.com'
 gives="notesnook"
 source=("https://raw.githubusercontent.com/streetwriters/notesnook/refs/tags/v${pkgver}/resources/icon.png")
 source_amd64=("${gives}-${pkgver}.AppImage::https://github.com/streetwriters/notesnook/releases/download/v${pkgver}/notesnook_linux_x86_64.AppImage")
 source_arm64=("${gives}-${pkgver}.AppImage::https://github.com/streetwriters/notesnook/releases/download/v${pkgver}/notesnook_linux_arm64.AppImage")
 sha256sums=('SKIP')
-sha256sums_amd64=("c49738761f754dcc6f07cdfae1b557a80ba9c97c599a928cceca1ee399869a12")
-sha256sums_arm64=("337b01516b68781e3a25f129d6841ee136e9c29aa0a31b50df5dd16e64b46864")
+sha256sums_amd64=("37035f853b9f276e70a9d66e45757bdda54e1e376a18f4388d974c5da5bedef3")
+sha256sums_arm64=("7408cb3a25afa33268cfc3bf7de2ab338fea13d5d2f3720d038202e20599b60d")
 pkgdesc="End-to-end encrypted note taking alternative to Evernote"
-maintainer=("villamorrd <villamorrd@students.nu-moa.edu.ph>")
+maintainer=("Tai Lam <taivlam-aur-mpr.tinsmith796@silomails.com>")
 license=('GPL-3.0-only')
 
 prepare() {

--- a/srclist
+++ b/srclist
@@ -11137,20 +11137,20 @@ pkgname = nordvpn-deb
 ---
 pkgbase = notesnook-app
 	gives = notesnook
-	pkgver = 3.3.23
+	pkgver = 3.4.7
 	pkgdesc = End-to-end encrypted note taking alternative to Evernote
 	url = https://notesnook.com
 	arch = amd64
 	arch = arm64
 	license = GPL-3.0-only
-	maintainer = villamorrd <villamorrd@students.nu-moa.edu.ph>
+	maintainer = Tai Lam <taivlam-aur-mpr.tinsmith796@silomails.com>
 	repology = project: notesnook
-	source = https://raw.githubusercontent.com/streetwriters/notesnook/refs/tags/v3.3.23/resources/icon.png
+	source = https://raw.githubusercontent.com/streetwriters/notesnook/refs/tags/v3.4.7/resources/icon.png
 	sha256sums = SKIP
-	source_amd64 = notesnook-3.3.23.AppImage::https://github.com/streetwriters/notesnook/releases/download/v3.3.23/notesnook_linux_x86_64.AppImage
-	sha256sums_amd64 = c49738761f754dcc6f07cdfae1b557a80ba9c97c599a928cceca1ee399869a12
-	source_arm64 = notesnook-3.3.23.AppImage::https://github.com/streetwriters/notesnook/releases/download/v3.3.23/notesnook_linux_arm64.AppImage
-	sha256sums_arm64 = 337b01516b68781e3a25f129d6841ee136e9c29aa0a31b50df5dd16e64b46864
+	source_amd64 = notesnook-3.4.7.AppImage::https://github.com/streetwriters/notesnook/releases/download/v3.4.7/notesnook_linux_x86_64.AppImage
+	sha256sums_amd64 = 37035f853b9f276e70a9d66e45757bdda54e1e376a18f4388d974c5da5bedef3
+	source_arm64 = notesnook-3.4.7.AppImage::https://github.com/streetwriters/notesnook/releases/download/v3.4.7/notesnook_linux_arm64.AppImage
+	sha256sums_arm64 = 7408cb3a25afa33268cfc3bf7de2ab338fea13d5d2f3720d038202e20599b60d
 
 pkgname = notesnook-app
 ---


### PR DESCRIPTION
* I would like to adopt this package, as Notesnook's desktop releases can range from weekly to monthly.
    * Although the package has been being updated, the listed maintainer hasn't performed any updates themselves since March 2025.
* I have e-mailed the maintainer since March 2025 at least twice to update the package, but never received a response.
    * The e-mail address (when I tried it) seemed valid and didn't bounce back any messages.