### PR TITLE
upd(vscode-deb): `1.135.0` -> `1.136.1`

### DIFF
--- a/packages/vscode-deb/.SRCINFO
+++ b/packages/vscode-deb/.SRCINFO
@@ -1,19 +1,20 @@
 pkgbase = vscode-deb
 	gives = code
-	pkgver = 1.136.0
+	pkgver = 1.136.1
 	pkgdesc = lightweight but powerful source code editor
 	url = https://code.visualstudio.com/
 	arch = amd64
 	arch = arm64
 	arch = armhf
 	makedepends = gpg
+	maintainer = Tobias Heinlein <niontrix@mailbox.org>
 	maintainer = Diegiwg <diegiwg@gmail.com>
 	repology = project: vscode
-	source_amd64 = https://packages.microsoft.com/repos/code/pool/main/c/code/code_1.136.0-1788342447_amd64.deb
-	sha256sums_amd64 = 7cc48f2cd51640c7c098740fa3f566dcbdbe5b47e91e86aaecec9d109e3631d3
-	source_arm64 = https://packages.microsoft.com/repos/code/pool/main/c/code/code_1.136.0-1788342618_arm64.deb
-	sha256sums_arm64 = f92d9cf4602efe15107bca44b47e9a16765829c755b60c3c1f3975e551798618
-	source_armhf = https://packages.microsoft.com/repos/code/pool/main/c/code/code_1.136.0-1788342292_armhf.deb
-	sha256sums_armhf = aabb727fa1914c90dd8f50aa90d3079a63d3fac09fe4219ccf634b3867644eb1
+	source_amd64 = vscode-amd64.deb::https://update.code.visualstudio.com/1.136.1/linux-deb-x64/stable
+	sha256sums_amd64 = 4463c4e249a19d7746603f2ec3745c345d3cd55b009d36e824158d15c35509ef
+	source_arm64 = vscode-arm64.deb::https://update.code.visualstudio.com/1.136.1/linux-deb-arm64/stable
+	sha256sums_arm64 = baa72f92d3feaa76d015202c57271475ea15809e635587279171a972cdd612a4
+	source_armhf = vscode-armhf.deb::https://update.code.visualstudio.com/1.136.1/linux-deb-armhf/stable
+	sha256sums_armhf = 02ddb5c5cbc2d5f4db25a3d7bb365c60eef0a017fa64b1994b131544677319e3
 
 pkgname = vscode-deb

--- a/packages/vscode-deb/vscode-deb.pacscript
+++ b/packages/vscode-deb/vscode-deb.pacscript
@@ -1,16 +1,16 @@
 pkgname="vscode-deb"
 arch=("amd64" "arm64" "armhf")
 gives="code"
-pkgver="1.136.0"
+pkgver="1.136.1"
 url='https://code.visualstudio.com/'
 pkgdesc="lightweight but powerful source code editor"
 repology=("project: vscode")
 makedepends=("gpg")
-maintainer=("Diegiwg <diegiwg@gmail.com>")
+maintainer=("Tobias Heinlein <niontrix@mailbox.org>" "Diegiwg <diegiwg@gmail.com>")
 
-source_amd64=("https://packages.microsoft.com/repos/code/pool/main/c/${gives}/${gives}_${pkgver}-1788342447_amd64.deb")
-source_arm64=("https://packages.microsoft.com/repos/code/pool/main/c/${gives}/${gives}_${pkgver}-1788342618_arm64.deb")
-source_armhf=("https://packages.microsoft.com/repos/code/pool/main/c/${gives}/${gives}_${pkgver}-1788342292_armhf.deb")
-sha256sums_amd64=("7cc48f2cd51640c7c098740fa3f566dcbdbe5b47e91e86aaecec9d109e3631d3")
-sha256sums_arm64=("f92d9cf4602efe15107bca44b47e9a16765829c755b60c3c1f3975e551798618")
-sha256sums_armhf=("aabb727fa1914c90dd8f50aa90d3079a63d3fac09fe4219ccf634b3867644eb1")
+source_amd64=("vscode-amd64.deb::https://update.code.visualstudio.com/${pkgver}/linux-deb-x64/stable")
+source_arm64=("vscode-arm64.deb::https://update.code.visualstudio.com/${pkgver}/linux-deb-arm64/stable")
+source_armhf=("vscode-armhf.deb::https://update.code.visualstudio.com/${pkgver}/linux-deb-armhf/stable")
+sha256sums_amd64=("4463c4e249a19d7746603f2ec3745c345d3cd55b009d36e824158d15c35509ef")
+sha256sums_arm64=("baa72f92d3feaa76d015202c57271475ea15809e635587279171a972cdd612a4")
+sha256sums_armhf=("02ddb5c5cbc2d5f4db25a3d7bb365c60eef0a017fa64b1994b131544677319e3")

--- a/srclist
+++ b/srclist
@@ -17948,21 +17948,22 @@ pkgname = vkroots-git
 ---
 pkgbase = vscode-deb
 	gives = code
-	pkgver = 1.136.0
+	pkgver = 1.136.1
 	pkgdesc = lightweight but powerful source code editor
 	url = https://code.visualstudio.com/
 	arch = amd64
 	arch = arm64
 	arch = armhf
 	makedepends = gpg
+	maintainer = Tobias Heinlein <niontrix@mailbox.org>
 	maintainer = Diegiwg <diegiwg@gmail.com>
 	repology = project: vscode
-	source_amd64 = https://packages.microsoft.com/repos/code/pool/main/c/code/code_1.136.0-1788342447_amd64.deb
-	sha256sums_amd64 = 7cc48f2cd51640c7c098740fa3f566dcbdbe5b47e91e86aaecec9d109e3631d3
-	source_arm64 = https://packages.microsoft.com/repos/code/pool/main/c/code/code_1.136.0-1788342618_arm64.deb
-	sha256sums_arm64 = f92d9cf4602efe15107bca44b47e9a16765829c755b60c3c1f3975e551798618
-	source_armhf = https://packages.microsoft.com/repos/code/pool/main/c/code/code_1.136.0-1788342292_armhf.deb
-	sha256sums_armhf = aabb727fa1914c90dd8f50aa90d3079a63d3fac09fe4219ccf634b3867644eb1
+	source_amd64 = vscode-amd64.deb::https://update.code.visualstudio.com/1.136.1/linux-deb-x64/stable
+	sha256sums_amd64 = 4463c4e249a19d7746603f2ec3745c345d3cd55b009d36e824158d15c35509ef
+	source_arm64 = vscode-arm64.deb::https://update.code.visualstudio.com/1.136.1/linux-deb-arm64/stable
+	sha256sums_arm64 = baa72f92d3feaa76d015202c57271475ea15809e635587279171a972cdd612a4
+	source_armhf = vscode-armhf.deb::https://update.code.visualstudio.com/1.136.1/linux-deb-armhf/stable
+	sha256sums_armhf = 02ddb5c5cbc2d5f4db25a3d7bb365c60eef0a017fa64b1994b131544677319e3
 
 pkgname = vscode-deb
 ---


### PR DESCRIPTION
I reversed the changes introduces by the latest update to `1.136.0`, because it broke the ability to update using `pacup` and `repology`.