### PR TITLE
upd(eclipse-rcp-bin): `4.40` -> `4.41`

### DIFF
--- a/packages/eclipse-rcp-bin/.SRCINFO
+++ b/packages/eclipse-rcp-bin/.SRCINFO
@@ -1,5 +1,5 @@
 pkgbase = eclipse-rcp-bin
-	pkgver = 4.40
+	pkgver = 4.41
 	pkgdesc = IDE for Rich Client Platform (RCP) and Remote Application Platform (RAP)
 	url = https://eclipse.org/ide
 	arch = amd64
@@ -8,9 +8,9 @@ pkgbase = eclipse-rcp-bin
 	license = EPL-2.0
 	maintainer = Matthias Mailänder <matthias@mailaender.name>
 	repology = project: eclipse-rcp
-	source = https://cdimage.debian.org/mirror/eclipse.org/technology/epp/downloads/release/2026-06/R/eclipse-rcp-2026-06-R-linux-gtk-x86_64.tar.gz
+	source = https://cdimage.debian.org/mirror/eclipse.org/technology/epp/downloads/release/2026-09/R/eclipse-rcp-2026-09-R-linux-gtk-x86_64.tar.gz
 	source = eclipse.desktop::https://raw.githubusercontent.com/eclipse-linuxtools/org.eclipse.linuxtools.eclipse-build/refs/heads/master/desktopintegration/eclipse.desktop
-	sha512sums = df0c35a056f4f151f0ee5ed36869aff023a2b9418ac1ef8b77938f4978de1a9c71b760e927b354175002a9e1385c981ad1d93a78561c30230945e589a6b97ecc
+	sha512sums = a727e8130f88547aff2912e4b6ff3ba1b2a525d24b853acbeb43aa69886d926188bb553847261314c530e98d35744697cbfeef76fb7b46152ab05b52beb2cded
 	sha512sums = bb5c1bbf07c52a68b123f40d35ffa1b09a0743003c734e53c0a0b23c4bb81a28c25b1be0c74b1507da8237db96b06f5e53baf6b6234bbc102e54602c30207291
 
 pkgname = eclipse-rcp-bin

--- a/packages/eclipse-rcp-bin/eclipse-rcp-bin.pacscript
+++ b/packages/eclipse-rcp-bin/eclipse-rcp-bin.pacscript
@@ -1,6 +1,6 @@
 pkgname="eclipse-rcp-bin"
-pkgver="4.40"
-_release="2026-06"
+pkgver="4.41"
+_release="2026-09"
 pkgdesc="IDE for Rich Client Platform (RCP) and Remote Application Platform (RAP)"
 arch=('amd64')
 url="https://eclipse.org/ide"
@@ -8,7 +8,7 @@ license=('EPL-2.0')
 depends=('libwebkit2gtk-4.1-0')
 source=("https://cdimage.debian.org/mirror/eclipse.org/technology/epp/downloads/release/${_release}/R/eclipse-rcp-${_release}-R-linux-gtk-x86_64.tar.gz"
   "eclipse.desktop::https://raw.githubusercontent.com/eclipse-linuxtools/org.eclipse.linuxtools.eclipse-build/refs/heads/master/desktopintegration/eclipse.desktop")
-sha512sums=('df0c35a056f4f151f0ee5ed36869aff023a2b9418ac1ef8b77938f4978de1a9c71b760e927b354175002a9e1385c981ad1d93a78561c30230945e589a6b97ecc'
+sha512sums=('a727e8130f88547aff2912e4b6ff3ba1b2a525d24b853acbeb43aa69886d926188bb553847261314c530e98d35744697cbfeef76fb7b46152ab05b52beb2cded'
   'bb5c1bbf07c52a68b123f40d35ffa1b09a0743003c734e53c0a0b23c4bb81a28c25b1be0c74b1507da8237db96b06f5e53baf6b6234bbc102e54602c30207291')
 backup=('usr/lib/eclipse/eclipse.ini')
 maintainer=("Matthias Mailänder <matthias@mailaender.name>")

--- a/srclist
+++ b/srclist
@@ -2987,7 +2987,7 @@ pkgbase = easy-zsh-config-git
 pkgname = easy-zsh-config-git
 ---
 pkgbase = eclipse-rcp-bin
-	pkgver = 4.40
+	pkgver = 4.41
 	pkgdesc = IDE for Rich Client Platform (RCP) and Remote Application Platform (RAP)
 	url = https://eclipse.org/ide
 	arch = amd64
@@ -2996,9 +2996,9 @@ pkgbase = eclipse-rcp-bin
 	license = EPL-2.0
 	maintainer = Matthias Mailänder <matthias@mailaender.name>
 	repology = project: eclipse-rcp
-	source = https://cdimage.debian.org/mirror/eclipse.org/technology/epp/downloads/release/2026-06/R/eclipse-rcp-2026-06-R-linux-gtk-x86_64.tar.gz
+	source = https://cdimage.debian.org/mirror/eclipse.org/technology/epp/downloads/release/2026-09/R/eclipse-rcp-2026-09-R-linux-gtk-x86_64.tar.gz
 	source = eclipse.desktop::https://raw.githubusercontent.com/eclipse-linuxtools/org.eclipse.linuxtools.eclipse-build/refs/heads/master/desktopintegration/eclipse.desktop
-	sha512sums = df0c35a056f4f151f0ee5ed36869aff023a2b9418ac1ef8b77938f4978de1a9c71b760e927b354175002a9e1385c981ad1d93a78561c30230945e589a6b97ecc
+	sha512sums = a727e8130f88547aff2912e4b6ff3ba1b2a525d24b853acbeb43aa69886d926188bb553847261314c530e98d35744697cbfeef76fb7b46152ab05b52beb2cded
 	sha512sums = bb5c1bbf07c52a68b123f40d35ffa1b09a0743003c734e53c0a0b23c4bb81a28c25b1be0c74b1507da8237db96b06f5e53baf6b6234bbc102e54602c30207291
 
 pkgname = eclipse-rcp-bin


### PR DESCRIPTION
https://eclipse.dev/eclipse/markdown/?f=news/4.41/index.md